### PR TITLE
SV-008: Add application management to server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,14 @@
-tests:
+SHELL=/bin/bash
+
+tests: mocks
 	go test ./...
+
+mocks: clean-mocks
+	@echo "+ $@"
+	$(shell) go generate ./...
+
+clean-mocks:
+	$(shell) find . -type f \( -name "*_mock.go" -o -name "mock_*.go" \) -print0 | xargs -0 rm -f
 
 # Starts a database container for local development
 run-db:
@@ -16,4 +25,3 @@ migrate_uri_up:
 
 migrate_uri_down:
 	migrate -path db/migrations -database "$(uri)" down
-

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL=/bin/bash
 
-tests: mocks
+tests:
 	go test ./...
 
 mocks: clean-mocks

--- a/README.md
+++ b/README.md
@@ -6,16 +6,21 @@ Server for the cosmos platform
 
 ```
 cosmos-server
+├── config              // Local configuration files
+├── api                   // Structs and validations of the server api requests and responses
+├── db                   // Utilities and migrations for the postgress database
 ├── pkg
-│   ├── app                  // Package where the app is defined and has the functions to be initialized.
-│   ├── api                  // Package where the API is defined
-│   │   ├── routes           // Package where the routes are defined.
-│   │   └── dto              // Package where the data transfer objects are defined.
-│   ├── config               // Package where the configuration format is defined.
-│   ├── server               // Package where the server is defined.
+│   ├── app            // Package where the app is defined and has the functions to be initialized.
+│   ├── config        // Package where there are structs and utilities for parsing configuration..
+│   ├── errors        // Package where there are definitions for various kinds of general errors.
+│   ├── log             // Package where the logger is defined.
+│   ├── model        // Package where the various model of our application are defined..
+│   ├── routes                  // Package where the route handlers for aour application are defined
+│   ├── server               // Package where the server and its middleware is defined.
 │   ├── services             // Package where the services are defined.
+│   ├── storage             // Package where the storage service is defined.
 │   └── test                 // Package where test utilities are defined
-└── config                   // Configuration files
+└── Makefile
 ```
 
 ## Requisites

--- a/api/application.go
+++ b/api/application.go
@@ -25,3 +25,7 @@ type Application struct {
 	Description string `json:"description"`
 	Team        *Team  `json:"team,omitempty"`
 }
+
+type GetApplicationsResponse struct {
+	Applications []*Application `json:"applications"`
+}

--- a/api/application.go
+++ b/api/application.go
@@ -1,0 +1,27 @@
+package api
+
+import validation "github.com/go-ozzo/ozzo-validation/v4"
+
+type CreateApplicationRequest struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Team        string `json:"team,omitempty"`
+}
+
+func (r *CreateApplicationRequest) Validate() error {
+	return validation.ValidateStruct(r,
+		validation.Field(&r.Name, validation.Required, validation.Length(1, 100)),
+		validation.Field(&r.Description, validation.Length(0, 500)),
+		validation.Field(&r.Team, validation.Length(0, 100)),
+	)
+}
+
+type CreateApplicationResponse struct {
+	Application *Application `json:"application"`
+}
+
+type Application struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Team        string `json:"team,omitempty"`
+}

--- a/api/application.go
+++ b/api/application.go
@@ -26,6 +26,10 @@ type Application struct {
 	Team        *Team  `json:"team,omitempty"`
 }
 
+type GetApplicationResponse struct {
+	Application *Application `json:"application"`
+}
+
 type GetApplicationsResponse struct {
 	Applications []*Application `json:"applications"`
 }

--- a/api/application.go
+++ b/api/application.go
@@ -23,5 +23,5 @@ type CreateApplicationResponse struct {
 type Application struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
-	Team        string `json:"team,omitempty"`
+	Team        *Team  `json:"team,omitempty"`
 }

--- a/api/team.go
+++ b/api/team.go
@@ -39,3 +39,7 @@ func (r *AddUserToTeamRequest) Validate() error {
 		validation.Field(&r.Email, validation.Required, validation.Length(1, 100), is.EmailFormat),
 	)
 }
+
+type GetTeamResponse struct {
+	Team *Team `json:"team"`
+}

--- a/api/user.go
+++ b/api/user.go
@@ -36,3 +36,7 @@ type User struct {
 type GetUsersResponse struct {
 	Users []*User `json:"users"`
 }
+
+type GetCurrentUserResponse struct {
+	User User `json:"user"`
+}

--- a/db/migrations/0003_create_applications.down.sql
+++ b/db/migrations/0003_create_applications.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS applications;

--- a/db/migrations/0003_create_applications.up.sql
+++ b/db/migrations/0003_create_applications.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS applications (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL UNIQUE,
+    description TEXT,
+    team_id INTEGER REFERENCES teams(id) ON DELETE SET NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX applications_name_idx ON applications(name);
+CREATE INDEX applications_team_id_idx ON applications(team_id);

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -6,6 +6,7 @@ import (
 	"cosmos-server/pkg/log"
 	"cosmos-server/pkg/routes"
 	"cosmos-server/pkg/server"
+	"cosmos-server/pkg/services/application"
 	"cosmos-server/pkg/services/auth"
 	"cosmos-server/pkg/services/team"
 	"cosmos-server/pkg/services/user"
@@ -33,8 +34,9 @@ func NewApp(config *c.Config) (*App, error) {
 	authService := auth.NewAuthService(config.AuthConfig, storageService, auth.NewTranslator(), logger)
 	userService := user.NewUserService(storageService, user.NewTranslator(), logger)
 	teamService := team.NewTeamService(storageService, team.NewTranslator())
+	applicationService := application.NewApplicationService(storageService, team.NewTranslator(), logger)
 
-	httpRoutes := routes.NewHTTPRoutes(authService, userService, teamService, logger)
+	httpRoutes := routes.NewHTTPRoutes(authService, userService, teamService, applicationService, logger)
 
 	return &App{
 		config: config,

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -34,7 +34,7 @@ func NewApp(config *c.Config) (*App, error) {
 	authService := auth.NewAuthService(config.AuthConfig, storageService, auth.NewTranslator(), logger)
 	userService := user.NewUserService(storageService, user.NewTranslator(), logger)
 	teamService := team.NewTeamService(storageService, team.NewTranslator())
-	applicationService := application.NewApplicationService(storageService, team.NewTranslator(), logger)
+	applicationService := application.NewApplicationService(storageService, application.NewTranslator(), logger)
 
 	httpRoutes := routes.NewHTTPRoutes(authService, userService, teamService, applicationService, logger)
 

--- a/pkg/model/application.go
+++ b/pkg/model/application.go
@@ -1,0 +1,7 @@
+package model
+
+type Application struct {
+	Name        string
+	Description string
+	Team        *Team
+}

--- a/pkg/routes/application/application.go
+++ b/pkg/routes/application/application.go
@@ -16,7 +16,7 @@ type handler struct {
 	logger             log.Logger
 }
 
-func AddApplicationHandler(e *gin.RouterGroup, applicationService application.Service, translator Translator, logger log.Logger) {
+func AddAuthenticatedApplicationHandler(e *gin.RouterGroup, applicationService application.Service, translator Translator, logger log.Logger) {
 	handler := &handler{
 		applicationService: applicationService,
 		translator:         translator,

--- a/pkg/routes/application/application.go
+++ b/pkg/routes/application/application.go
@@ -28,7 +28,7 @@ func AddApplicationHandler(e *gin.RouterGroup, applicationService application.Se
 	applicationsGroup.GET("/:application", handler.handleGetApplication)
 	applicationsGroup.GET("", handler.handleGetApplications)
 	applicationsGroup.POST("", handler.handleCreateApplication)
-	//applicationsGroup.DELETE("/:id", handler.handleDeleteApplication)
+	applicationsGroup.DELETE("/:application", handler.handleDeleteApplication)
 }
 
 func (handler *handler) handleCreateApplication(e *gin.Context) {
@@ -80,4 +80,20 @@ func (handler *handler) handleGetApplications(e *gin.Context) {
 	}
 
 	e.JSON(http.StatusOK, handler.translator.ToGetApplicationsResponse(applications))
+}
+
+func (handler *handler) handleDeleteApplication(e *gin.Context) {
+	applicationName := e.Param("application")
+	if applicationName == "" {
+		_ = e.Error(errors.NewBadRequestError("application name missing"))
+		return
+	}
+
+	err := handler.applicationService.DeleteApplication(e, applicationName)
+	if err != nil {
+		_ = e.Error(err)
+		return
+	}
+
+	e.Status(http.StatusNoContent)
 }

--- a/pkg/routes/application/application.go
+++ b/pkg/routes/application/application.go
@@ -7,6 +7,7 @@ import (
 	"cosmos-server/pkg/services/application"
 	"fmt"
 	"github.com/gin-gonic/gin"
+	"net/http"
 )
 
 type handler struct {
@@ -24,7 +25,7 @@ func AddApplicationHandler(e *gin.RouterGroup, applicationService application.Se
 
 	applicationsGroup := e.Group("/applications")
 
-	//applicationsGroup.GET("", handler.handleGetApplications)
+	applicationsGroup.GET("/:application", handler.handleGetApplication)
 	applicationsGroup.POST("", handler.handleCreateApplication)
 	//applicationsGroup.DELETE("/:id", handler.handleDeleteApplication)
 }
@@ -49,5 +50,22 @@ func (handler *handler) handleCreateApplication(e *gin.Context) {
 		return
 	}
 
-	e.JSON(201, handler.translator.ToCreateApplicationResponse(createApplicationRequest.Name, createApplicationRequest.Description, createApplicationRequest.Team))
+	e.JSON(http.StatusCreated, handler.translator.ToCreateApplicationResponse(createApplicationRequest.Name, createApplicationRequest.Description, createApplicationRequest.Team))
+}
+
+func (handler *handler) handleGetApplication(e *gin.Context) {
+
+	applicationName := e.Param("application")
+	if applicationName == "" {
+		_ = e.Error(errors.NewBadRequestError("application name missing"))
+	}
+
+	app, err := handler.applicationService.GetApplication(e, applicationName)
+	if err != nil {
+		_ = e.Error(err)
+		return
+	}
+
+	e.JSON(http.StatusOK, handler.translator.ToGetApplicationResponse(app))
+
 }

--- a/pkg/routes/application/application.go
+++ b/pkg/routes/application/application.go
@@ -1,0 +1,53 @@
+package application
+
+import (
+	"cosmos-server/api"
+	"cosmos-server/pkg/errors"
+	"cosmos-server/pkg/log"
+	"cosmos-server/pkg/services/application"
+	"fmt"
+	"github.com/gin-gonic/gin"
+)
+
+type handler struct {
+	applicationService application.Service
+	translator         Translator
+	logger             log.Logger
+}
+
+func AddApplicationHandler(e *gin.RouterGroup, applicationService application.Service, translator Translator, logger log.Logger) {
+	handler := &handler{
+		applicationService: applicationService,
+		translator:         translator,
+		logger:             logger,
+	}
+
+	applicationsGroup := e.Group("/applications")
+
+	//applicationsGroup.GET("", handler.handleGetApplications)
+	applicationsGroup.POST("", handler.handleCreateApplication)
+	//applicationsGroup.DELETE("/:id", handler.handleDeleteApplication)
+}
+
+func (handler *handler) handleCreateApplication(e *gin.Context) {
+	var createApplicationRequest api.CreateApplicationRequest
+
+	if err := e.ShouldBindJSON(&createApplicationRequest); err != nil {
+		handler.logger.Errorf("Failed to bind JSON for registration request: %v", err)
+		_ = e.Error(errors.NewBadRequestError(fmt.Sprintf("Invalid request format: %v", err)))
+		return
+	}
+
+	if err := createApplicationRequest.Validate(); err != nil {
+		_ = e.Error(errors.NewBadRequestError(err.Error()))
+		return
+	}
+
+	err := handler.applicationService.AddApplication(e, createApplicationRequest.Name, createApplicationRequest.Description, createApplicationRequest.Team)
+	if err != nil {
+		_ = e.Error(err)
+		return
+	}
+
+	e.JSON(201, handler.translator.ToCreateApplicationResponse(createApplicationRequest.Name, createApplicationRequest.Description, createApplicationRequest.Team))
+}

--- a/pkg/routes/application/application.go
+++ b/pkg/routes/application/application.go
@@ -26,6 +26,7 @@ func AddApplicationHandler(e *gin.RouterGroup, applicationService application.Se
 	applicationsGroup := e.Group("/applications")
 
 	applicationsGroup.GET("/:application", handler.handleGetApplication)
+	applicationsGroup.GET("", handler.handleGetApplications)
 	applicationsGroup.POST("", handler.handleCreateApplication)
 	//applicationsGroup.DELETE("/:id", handler.handleDeleteApplication)
 }
@@ -54,10 +55,10 @@ func (handler *handler) handleCreateApplication(e *gin.Context) {
 }
 
 func (handler *handler) handleGetApplication(e *gin.Context) {
-
 	applicationName := e.Param("application")
 	if applicationName == "" {
 		_ = e.Error(errors.NewBadRequestError("application name missing"))
+		return
 	}
 
 	app, err := handler.applicationService.GetApplication(e, applicationName)
@@ -67,5 +68,16 @@ func (handler *handler) handleGetApplication(e *gin.Context) {
 	}
 
 	e.JSON(http.StatusOK, handler.translator.ToGetApplicationResponse(app))
+}
 
+func (handler *handler) handleGetApplications(e *gin.Context) {
+	name := e.Query("name")
+
+	applications, err := handler.applicationService.GetApplicationsWithFilter(e, name)
+	if err != nil {
+		_ = e.Error(err)
+		return
+	}
+
+	e.JSON(http.StatusOK, handler.translator.ToGetApplicationsResponse(applications))
 }

--- a/pkg/routes/application/application.go
+++ b/pkg/routes/application/application.go
@@ -27,6 +27,7 @@ func AddApplicationHandler(e *gin.RouterGroup, applicationService application.Se
 
 	applicationsGroup.GET("/:application", handler.handleGetApplication)
 	applicationsGroup.GET("", handler.handleGetApplications)
+	applicationsGroup.GET("/team/:teamName", handler.handleGetApplicationByTeam)
 	applicationsGroup.POST("", handler.handleCreateApplication)
 	applicationsGroup.DELETE("/:application", handler.handleDeleteApplication)
 }
@@ -74,6 +75,22 @@ func (handler *handler) handleGetApplications(e *gin.Context) {
 	name := e.Query("name")
 
 	applications, err := handler.applicationService.GetApplicationsWithFilter(e, name)
+	if err != nil {
+		_ = e.Error(err)
+		return
+	}
+
+	e.JSON(http.StatusOK, handler.translator.ToGetApplicationsResponse(applications))
+}
+
+func (handler *handler) handleGetApplicationByTeam(e *gin.Context) {
+	teamName := e.Param("teamName")
+	if teamName == "" {
+		_ = e.Error(errors.NewBadRequestError("team name missing"))
+		return
+	}
+
+	applications, err := handler.applicationService.GetApplicationsByTeam(e, teamName)
 	if err != nil {
 		_ = e.Error(err)
 		return

--- a/pkg/routes/application/application_test.go
+++ b/pkg/routes/application/application_test.go
@@ -40,7 +40,7 @@ func setUp(t *testing.T) (*gin.Engine, *mocks) {
 
 func TestHandleCreateApplication(t *testing.T) {
 	t.Run("success - create application", handleCreateApplicationSuccess)
-	//t.Run("failure - name required", handleCreateApplicationNameRequired)
+	t.Run("failure - name required", handleCreateApplicationNameRequired)
 	//t.Run("failure - description required", handleCreateApplicationDescriptionRequired)
 	//t.Run("failure - team required", handleCreateApplicationTeamRequired)
 	//t.Run("failure - insert application error", handleCreateApplicationInsertApplicationError)
@@ -93,38 +93,38 @@ func handleCreateApplicationSuccess(t *testing.T) {
 	require.Equal(t, expectedResponse, &actualResponse, "Response body mismatch")
 }
 
-//func handleCreateApplicationNameRequired(t *testing.T) {
-//	router, mocks := setUp(t)
-//
-//	mockedDescription := "Test application description"
-//	mockedTeam := "test-team"
-//
-//	mockedCreateApplicationRequest := &api.CreateApplicationRequest{
-//		Description: mockedDescription,
-//		Team:        mockedTeam,
-//	}
-//
-//	mocks.loggerMock.EXPECT().
-//		Errorf(gomock.Any(), gomock.Any())
-//
-//	url := "/applications"
-//
-//	request, recorder, err := test.NewHTTPRequest("POST", url, mockedCreateApplicationRequest)
-//	if err != nil {
-//		t.Fatalf("Failed to create request: %v", err)
-//	}
-//
-//	router.ServeHTTP(recorder, request)
-//
-//	actualResponse := api.ErrorResponse{}
-//	err = json.NewDecoder(recorder.Body).Decode(&actualResponse)
-//	if err != nil {
-//		t.Fatalf("Failed to decode response: %v", err)
-//	}
-//
-//	require.Equal(t, http.StatusBadRequest, recorder.Code, "Expected status code 400")
-//}
-//
+func handleCreateApplicationNameRequired(t *testing.T) {
+	router, mocks := setUp(t)
+
+	mockedDescription := "Test application description"
+	mockedTeam := "test-team"
+
+	mockedCreateApplicationRequest := &api.CreateApplicationRequest{
+		Description: mockedDescription,
+		Team:        mockedTeam,
+	}
+
+	mocks.loggerMock.EXPECT().
+		Infow(gomock.Any(), gomock.Any())
+
+	url := "/applications"
+
+	request, recorder, err := test.NewHTTPRequest("POST", url, mockedCreateApplicationRequest)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	router.ServeHTTP(recorder, request)
+
+	actualResponse := api.ErrorResponse{}
+	err = json.NewDecoder(recorder.Body).Decode(&actualResponse)
+	if err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	require.Equal(t, http.StatusBadRequest, recorder.Code, "Expected status code 400")
+}
+
 //func handleCreateApplicationDescriptionRequired(t *testing.T) {
 //	router, mocks := setUp(t)
 //

--- a/pkg/routes/application/application_test.go
+++ b/pkg/routes/application/application_test.go
@@ -1,0 +1,236 @@
+package application
+
+import (
+	"cosmos-server/api"
+	log "cosmos-server/pkg/log/mock"
+	applicationMock "cosmos-server/pkg/services/application/mock"
+	"cosmos-server/pkg/test"
+	"encoding/json"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"net/http"
+	"testing"
+)
+
+type mocks struct {
+	controller             *gomock.Controller
+	applicationServiceMock *applicationMock.MockService
+	loggerMock             *log.MockLogger
+}
+
+func setUp(t *testing.T) (*gin.Engine, *mocks) {
+	ctrl := gomock.NewController(t)
+
+	applicationServiceMock := applicationMock.NewMockService(ctrl)
+	loggerMock := log.NewMockLogger(ctrl)
+
+	mocks := &mocks{
+		controller:             ctrl,
+		applicationServiceMock: applicationServiceMock,
+		loggerMock:             loggerMock,
+	}
+
+	router := test.NewRouter(loggerMock)
+
+	AddApplicationHandler(router.Group("/"), applicationServiceMock, NewTranslator(), loggerMock)
+
+	return router, mocks
+}
+
+func TestHandleCreateApplication(t *testing.T) {
+	t.Run("success - create application", handleCreateApplicationSuccess)
+	//t.Run("failure - name required", handleCreateApplicationNameRequired)
+	//t.Run("failure - description required", handleCreateApplicationDescriptionRequired)
+	//t.Run("failure - team required", handleCreateApplicationTeamRequired)
+	//t.Run("failure - insert application error", handleCreateApplicationInsertApplicationError)
+}
+
+func handleCreateApplicationSuccess(t *testing.T) {
+	router, mocks := setUp(t)
+
+	mockedName := "test-app"
+	mockedDescription := "Test application description"
+	mockedTeam := "test-team"
+
+	mockedCreateApplicationRequest := &api.CreateApplicationRequest{
+		Name:        mockedName,
+		Description: mockedDescription,
+		Team:        mockedTeam,
+	}
+
+	expectedResponse := &api.CreateApplicationResponse{
+		Application: &api.Application{
+			Name:        mockedName,
+			Description: mockedDescription,
+			Team:        &api.Team{Name: mockedTeam},
+		},
+	}
+
+	mocks.applicationServiceMock.EXPECT().
+		AddApplication(gomock.Any(), mockedName, mockedDescription, mockedTeam).
+		Return(nil)
+
+	mocks.loggerMock.EXPECT().
+		Infow(gomock.Any(), gomock.Any())
+
+	url := "/applications"
+
+	request, recorder, err := test.NewHTTPRequest("POST", url, mockedCreateApplicationRequest)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	router.ServeHTTP(recorder, request)
+
+	actualResponse := api.CreateApplicationResponse{}
+	err = json.NewDecoder(recorder.Body).Decode(&actualResponse)
+	if err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	require.Equal(t, http.StatusCreated, recorder.Code, "Expected status code 201")
+	require.Equal(t, expectedResponse, &actualResponse, "Response body mismatch")
+}
+
+//func handleCreateApplicationNameRequired(t *testing.T) {
+//	router, mocks := setUp(t)
+//
+//	mockedDescription := "Test application description"
+//	mockedTeam := "test-team"
+//
+//	mockedCreateApplicationRequest := &api.CreateApplicationRequest{
+//		Description: mockedDescription,
+//		Team:        mockedTeam,
+//	}
+//
+//	mocks.loggerMock.EXPECT().
+//		Errorf(gomock.Any(), gomock.Any())
+//
+//	url := "/applications"
+//
+//	request, recorder, err := test.NewHTTPRequest("POST", url, mockedCreateApplicationRequest)
+//	if err != nil {
+//		t.Fatalf("Failed to create request: %v", err)
+//	}
+//
+//	router.ServeHTTP(recorder, request)
+//
+//	actualResponse := api.ErrorResponse{}
+//	err = json.NewDecoder(recorder.Body).Decode(&actualResponse)
+//	if err != nil {
+//		t.Fatalf("Failed to decode response: %v", err)
+//	}
+//
+//	require.Equal(t, http.StatusBadRequest, recorder.Code, "Expected status code 400")
+//}
+//
+//func handleCreateApplicationDescriptionRequired(t *testing.T) {
+//	router, mocks := setUp(t)
+//
+//	mockedName := "test-app"
+//	mockedTeam := "test-team"
+//
+//	// Create request with description exceeding 500 characters to trigger validation error
+//	longDescription := make([]byte, 501)
+//	for i := range longDescription {
+//		longDescription[i] = 'a'
+//	}
+//
+//	mockedCreateApplicationRequest := &api.CreateApplicationRequest{
+//		Name:        mockedName,
+//		Description: string(longDescription),
+//		Team:        mockedTeam,
+//	}
+//
+//	url := "/applications"
+//
+//	request, recorder, err := test.NewHTTPRequest("POST", url, mockedCreateApplicationRequest)
+//	if err != nil {
+//		t.Fatalf("Failed to create request: %v", err)
+//	}
+//
+//	router.ServeHTTP(recorder, request)
+//
+//	actualResponse := api.ErrorResponse{}
+//	err = json.NewDecoder(recorder.Body).Decode(&actualResponse)
+//	if err != nil {
+//		t.Fatalf("Failed to decode response: %v", err)
+//	}
+//
+//	require.Equal(t, http.StatusBadRequest, recorder.Code, "Expected status code 400")
+//}
+//
+//func handleCreateApplicationTeamRequired(t *testing.T) {
+//	router, mocks := setUp(t)
+//
+//	mockedName := "test-app"
+//	mockedDescription := "Test application description"
+//
+//	// Create request with team exceeding 100 characters to trigger validation error
+//	longTeam := make([]byte, 101)
+//	for i := range longTeam {
+//		longTeam[i] = 'a'
+//	}
+//
+//	mockedCreateApplicationRequest := &api.CreateApplicationRequest{
+//		Name:        mockedName,
+//		Description: mockedDescription,
+//		Team:        string(longTeam),
+//	}
+//
+//	url := "/applications"
+//
+//	request, recorder, err := test.NewHTTPRequest("POST", url, mockedCreateApplicationRequest)
+//	if err != nil {
+//		t.Fatalf("Failed to create request: %v", err)
+//	}
+//
+//	router.ServeHTTP(recorder, request)
+//
+//	actualResponse := api.ErrorResponse{}
+//	err = json.NewDecoder(recorder.Body).Decode(&actualResponse)
+//	if err != nil {
+//		t.Fatalf("Failed to decode response: %v", err)
+//	}
+//
+//	require.Equal(t, http.StatusBadRequest, recorder.Code, "Expected status code 400")
+//}
+//
+//func handleCreateApplicationInsertApplicationError(t *testing.T) {
+//	router, mocks := setUp(t)
+//
+//	mockedName := "test-app"
+//	mockedDescription := "Test application description"
+//	mockedTeam := "test-team"
+//
+//	mockedCreateApplicationRequest := &api.CreateApplicationRequest{
+//		Name:        mockedName,
+//		Description: mockedDescription,
+//		Team:        mockedTeam,
+//	}
+//
+//	mockedError := errors.NewInternalServerError("Internal test error")
+//
+//	mocks.applicationServiceMock.EXPECT().
+//		AddApplication(gomock.Any(), mockedName, mockedDescription, mockedTeam).
+//		Return(mockedError)
+//
+//	url := "/applications"
+//
+//	request, recorder, err := test.NewHTTPRequest("POST", url, mockedCreateApplicationRequest)
+//	if err != nil {
+//		t.Fatalf("Failed to create request: %v", err)
+//	}
+//
+//	router.ServeHTTP(recorder, request)
+//
+//	actualResponse := api.ErrorResponse{}
+//	err = json.NewDecoder(recorder.Body).Decode(&actualResponse)
+//	if err != nil {
+//		t.Fatalf("Failed to decode response: %v", err)
+//	}
+//
+//	require.Equal(t, http.StatusInternalServerError, recorder.Code)
+//	require.Equal(t, "Internal test error", actualResponse.Error)
+//}

--- a/pkg/routes/application/application_test.go
+++ b/pkg/routes/application/application_test.go
@@ -203,6 +203,10 @@ func handleGetApplicationSuccess(t *testing.T) {
 		Team:        &model.Team{Name: mockedTeam},
 	}
 
+	expectedResponse := &api.GetApplicationResponse{
+		Application: mockedApplication,
+	}
+
 	mocks.applicationServiceMock.EXPECT().
 		GetApplication(gomock.Any(), mockedName).
 		Return(mockedApplicationModel, nil)
@@ -219,14 +223,14 @@ func handleGetApplicationSuccess(t *testing.T) {
 
 	router.ServeHTTP(recorder, request)
 
-	actualResponse := api.Application{}
+	actualResponse := api.GetApplicationResponse{}
 	err = json.NewDecoder(recorder.Body).Decode(&actualResponse)
 	if err != nil {
 		t.Fatalf("Failed to decode response: %v", err)
 	}
 
 	require.Equal(t, http.StatusOK, recorder.Code, "Expected status code 200")
-	require.Equal(t, mockedApplication, &actualResponse, "Response body mismatch")
+	require.Equal(t, expectedResponse, &actualResponse, "Response body mismatch")
 }
 
 func handleGetApplicationError(t *testing.T) {

--- a/pkg/routes/application/application_test.go
+++ b/pkg/routes/application/application_test.go
@@ -64,7 +64,7 @@ func setUp(t *testing.T) (*gin.Engine, *mocks) {
 
 	router := test.NewRouter(loggerMock)
 
-	AddApplicationHandler(router.Group("/"), applicationServiceMock, NewTranslator(), loggerMock)
+	AddAuthenticatedApplicationHandler(router.Group("/"), applicationServiceMock, NewTranslator(), loggerMock)
 
 	return router, mocks
 }

--- a/pkg/routes/application/translator.go
+++ b/pkg/routes/application/translator.go
@@ -8,6 +8,7 @@ import (
 type Translator interface {
 	ToCreateApplicationResponse(name, description, team string) *api.CreateApplicationResponse
 	ToGetApplicationResponse(applicationObj *model.Application) *api.Application
+	ToGetApplicationsResponse(applicationObj []*model.Application) *api.GetApplicationsResponse
 }
 
 type translator struct{}
@@ -41,5 +42,15 @@ func (t *translator) ToApiTeam(teamModel *model.Team) *api.Team {
 	return &api.Team{
 		Name:        teamModel.Name,
 		Description: teamModel.Description,
+	}
+}
+
+func (t *translator) ToGetApplicationsResponse(applicationModels []*model.Application) *api.GetApplicationsResponse {
+	var applications []*api.Application
+	for _, applicationModel := range applicationModels {
+		applications = append(applications, t.ToGetApplicationResponse(applicationModel))
+	}
+	return &api.GetApplicationsResponse{
+		Applications: applications,
 	}
 }

--- a/pkg/routes/application/translator.go
+++ b/pkg/routes/application/translator.go
@@ -7,7 +7,7 @@ import (
 
 type Translator interface {
 	ToCreateApplicationResponse(name, description, team string) *api.CreateApplicationResponse
-	ToGetApplicationResponse(applicationObj *model.Application) *api.Application
+	ToGetApplicationResponse(applicationObj *model.Application) *api.GetApplicationResponse
 	ToGetApplicationsResponse(applicationObj []*model.Application) *api.GetApplicationsResponse
 }
 
@@ -27,11 +27,9 @@ func (t *translator) ToCreateApplicationResponse(name, description, team string)
 	}
 }
 
-func (t *translator) ToGetApplicationResponse(applicationModel *model.Application) *api.Application {
-	return &api.Application{
-		Name:        applicationModel.Name,
-		Description: applicationModel.Description,
-		Team:        t.ToApiTeam(applicationModel.Team),
+func (t *translator) ToGetApplicationResponse(applicationModel *model.Application) *api.GetApplicationResponse {
+	return &api.GetApplicationResponse{
+		Application: t.ToApplicationApi(applicationModel),
 	}
 }
 
@@ -48,9 +46,17 @@ func (t *translator) ToApiTeam(teamModel *model.Team) *api.Team {
 func (t *translator) ToGetApplicationsResponse(applicationModels []*model.Application) *api.GetApplicationsResponse {
 	var applications []*api.Application
 	for _, applicationModel := range applicationModels {
-		applications = append(applications, t.ToGetApplicationResponse(applicationModel))
+		applications = append(applications, t.ToApplicationApi(applicationModel))
 	}
 	return &api.GetApplicationsResponse{
 		Applications: applications,
+	}
+}
+
+func (t *translator) ToApplicationApi(applicationModel *model.Application) *api.Application {
+	return &api.Application{
+		Name:        applicationModel.Name,
+		Description: applicationModel.Description,
+		Team:        t.ToApiTeam(applicationModel.Team),
 	}
 }

--- a/pkg/routes/application/translator.go
+++ b/pkg/routes/application/translator.go
@@ -1,9 +1,13 @@
 package application
 
-import "cosmos-server/api"
+import (
+	"cosmos-server/api"
+	"cosmos-server/pkg/model"
+)
 
 type Translator interface {
 	ToCreateApplicationResponse(name, description, team string) *api.CreateApplicationResponse
+	ToGetApplicationResponse(applicationObj *model.Application) *api.Application
 }
 
 type translator struct{}
@@ -17,7 +21,25 @@ func (t *translator) ToCreateApplicationResponse(name, description, team string)
 		Application: &api.Application{
 			Name:        name,
 			Description: description,
-			Team:        team,
+			Team:        &api.Team{Name: team},
 		},
+	}
+}
+
+func (t *translator) ToGetApplicationResponse(applicationModel *model.Application) *api.Application {
+	return &api.Application{
+		Name:        applicationModel.Name,
+		Description: applicationModel.Description,
+		Team:        t.ToApiTeam(applicationModel.Team),
+	}
+}
+
+func (t *translator) ToApiTeam(teamModel *model.Team) *api.Team {
+	if teamModel == nil {
+		return nil
+	}
+	return &api.Team{
+		Name:        teamModel.Name,
+		Description: teamModel.Description,
 	}
 }

--- a/pkg/routes/application/translator.go
+++ b/pkg/routes/application/translator.go
@@ -1,0 +1,23 @@
+package application
+
+import "cosmos-server/api"
+
+type Translator interface {
+	ToCreateApplicationResponse(name, description, team string) *api.CreateApplicationResponse
+}
+
+type translator struct{}
+
+func NewTranslator() Translator {
+	return &translator{}
+}
+
+func (t *translator) ToCreateApplicationResponse(name, description, team string) *api.CreateApplicationResponse {
+	return &api.CreateApplicationResponse{
+		Application: &api.Application{
+			Name:        name,
+			Description: description,
+			Team:        team,
+		},
+	}
+}

--- a/pkg/routes/routes.go
+++ b/pkg/routes/routes.go
@@ -39,7 +39,9 @@ func (r *HTTPRoutes) RegisterUnauthenticatedRoutes(e *gin.RouterGroup) {
 }
 
 func (r *HTTPRoutes) RegisterAuthenticatedRoutes(e *gin.RouterGroup) {
-	applicationRoute.AddApplicationHandler(e, r.ApplicationService, applicationRoute.NewTranslator(), r.Logger)
+	applicationRoute.AddAuthenticatedApplicationHandler(e, r.ApplicationService, applicationRoute.NewTranslator(), r.Logger)
+	userRoute.AddAuthenticatedUserHandler(e, r.UserService, userRoute.NewTranslator(), r.Logger)
+	teamRoute.AddAuthenticatedTeamHandler(e, r.TeamService, teamRoute.NewTranslator())
 }
 
 func (r *HTTPRoutes) RegisterAdminAuthenticatedRoutes(e *gin.RouterGroup) {

--- a/pkg/routes/routes.go
+++ b/pkg/routes/routes.go
@@ -2,35 +2,44 @@ package routes
 
 import (
 	"cosmos-server/pkg/log"
-	authRoute "cosmos-server/pkg/routes/auth"
-	healthcheckRoute "cosmos-server/pkg/routes/healthcheck"
-	teamRoute "cosmos-server/pkg/routes/team"
-	userRoute "cosmos-server/pkg/routes/user"
+	"cosmos-server/pkg/services/application"
 	"cosmos-server/pkg/services/auth"
 	"cosmos-server/pkg/services/team"
 	"cosmos-server/pkg/services/user"
 	"github.com/gin-gonic/gin"
+
+	applicationRoute "cosmos-server/pkg/routes/application"
+	authRoute "cosmos-server/pkg/routes/auth"
+	healthcheckRoute "cosmos-server/pkg/routes/healthcheck"
+	teamRoute "cosmos-server/pkg/routes/team"
+	userRoute "cosmos-server/pkg/routes/user"
 )
 
 type HTTPRoutes struct {
-	AuthService auth.Service
-	UserService user.Service
-	TeamService team.Service
-	Logger      log.Logger
+	AuthService        auth.Service
+	UserService        user.Service
+	TeamService        team.Service
+	ApplicationService application.Service
+	Logger             log.Logger
 }
 
-func NewHTTPRoutes(authService auth.Service, userService user.Service, teamService team.Service, logger log.Logger) *HTTPRoutes {
+func NewHTTPRoutes(authService auth.Service, userService user.Service, teamService team.Service, applicationService application.Service, logger log.Logger) *HTTPRoutes {
 	return &HTTPRoutes{
-		AuthService: authService,
-		UserService: userService,
-		TeamService: teamService,
-		Logger:      logger,
+		AuthService:        authService,
+		UserService:        userService,
+		TeamService:        teamService,
+		ApplicationService: applicationService,
+		Logger:             logger,
 	}
 }
 
 func (r *HTTPRoutes) RegisterUnauthenticatedRoutes(e *gin.RouterGroup) {
 	authRoute.AddAuthHandler(e, r.AuthService, r.Logger)
 	healthcheckRoute.AddHealthcheckHandler(e)
+}
+
+func (r *HTTPRoutes) RegisterAuthenticatedRoutes(e *gin.RouterGroup) {
+	applicationRoute.AddApplicationHandler(e, r.ApplicationService, applicationRoute.NewTranslator(), r.Logger)
 }
 
 func (r *HTTPRoutes) RegisterAdminAuthenticatedRoutes(e *gin.RouterGroup) {

--- a/pkg/routes/team/team.go
+++ b/pkg/routes/team/team.go
@@ -20,13 +20,21 @@ func AddAdminTeamHandler(e *gin.RouterGroup, teamService team.Service, translato
 		translator:  translator,
 	}
 
-	e.GET("/teams", h.handleGetTeams)
 	e.GET("/teams/:teamName", h.handleGetTeam)
 	e.POST("/teams", h.handleCreateTeam)
 	e.DELETE("/teams/:teamName", h.handleDeleteTeam)
 
 	e.POST("/teams/:teamName/members", h.handleAddUserToTeam)
 	e.DELETE("/teams/:teamName/members", h.handleRemoveUserFromTeam)
+}
+
+func AddAuthenticatedTeamHandler(e *gin.RouterGroup, teamService team.Service, translator Translator) {
+	h := &handler{
+		teamService: teamService,
+		translator:  translator,
+	}
+
+	e.GET("/teams", h.handleGetTeams)
 }
 
 func (h *handler) handleGetTeams(c *gin.Context) {

--- a/pkg/routes/team/team.go
+++ b/pkg/routes/team/team.go
@@ -22,7 +22,7 @@ func AddAdminTeamHandler(e *gin.RouterGroup, teamService team.Service, translato
 
 	e.GET("/teams", h.handleGetTeams)
 	e.POST("/teams", h.handleCreateTeam)
-	e.DELETE("/teams", h.handleDeleteTeam)
+	e.DELETE("/teams/:teamName", h.handleDeleteTeam)
 
 	e.POST("/teams/:teamName/members", h.handleAddUserToTeam)
 	e.DELETE("/teams/:teamName/members", h.handleRemoveUserFromTeam)
@@ -39,7 +39,7 @@ func (h *handler) handleGetTeams(c *gin.Context) {
 }
 
 func (h *handler) handleDeleteTeam(c *gin.Context) {
-	name := c.Query("name")
+	name := c.Param("teamName")
 	if name == "" {
 		_ = c.Error(errors.NewBadRequestError("team name is required"))
 		return

--- a/pkg/routes/team/team.go
+++ b/pkg/routes/team/team.go
@@ -6,6 +6,7 @@ import (
 	"cosmos-server/pkg/services/team"
 	"fmt"
 	"github.com/gin-gonic/gin"
+	"net/http"
 )
 
 type handler struct {
@@ -50,7 +51,7 @@ func (h *handler) handleDeleteTeam(c *gin.Context) {
 		return
 	}
 
-	c.Status(204)
+	c.Status(http.StatusNoContent)
 }
 
 func (h *handler) handleCreateTeam(c *gin.Context) {
@@ -73,7 +74,7 @@ func (h *handler) handleCreateTeam(c *gin.Context) {
 		return
 	}
 
-	c.JSON(201, h.translator.ToInsertTeamResponse(teamRequest.Name, teamRequest.Description))
+	c.JSON(http.StatusCreated, h.translator.ToInsertTeamResponse(teamRequest.Name, teamRequest.Description))
 }
 
 func (h *handler) handleAddUserToTeam(c *gin.Context) {
@@ -100,7 +101,7 @@ func (h *handler) handleAddUserToTeam(c *gin.Context) {
 		return
 	}
 
-	c.Status(204)
+	c.Status(http.StatusNoContent)
 }
 
 func (h *handler) handleRemoveUserFromTeam(c *gin.Context) {
@@ -128,5 +129,5 @@ func (h *handler) handleRemoveUserFromTeam(c *gin.Context) {
 		return
 	}
 
-	c.Status(204)
+	c.Status(http.StatusNoContent)
 }

--- a/pkg/routes/team/team.go
+++ b/pkg/routes/team/team.go
@@ -21,6 +21,7 @@ func AddAdminTeamHandler(e *gin.RouterGroup, teamService team.Service, translato
 	}
 
 	e.GET("/teams", h.handleGetTeams)
+	e.GET("/teams/:teamName", h.handleGetTeam)
 	e.POST("/teams", h.handleCreateTeam)
 	e.DELETE("/teams/:teamName", h.handleDeleteTeam)
 
@@ -130,4 +131,20 @@ func (h *handler) handleRemoveUserFromTeam(c *gin.Context) {
 	}
 
 	c.Status(http.StatusNoContent)
+}
+
+func (h *handler) handleGetTeam(c *gin.Context) {
+	teamName := c.Param("teamName")
+	if teamName == "" {
+		_ = c.Error(errors.NewBadRequestError("team name is required"))
+		return
+	}
+
+	teamModel, err := h.teamService.GetTeamByName(c, teamName)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	c.JSON(200, h.translator.ToGetTeamResponse(teamModel))
 }

--- a/pkg/routes/team/team_test.go
+++ b/pkg/routes/team/team_test.go
@@ -7,6 +7,7 @@ import (
 	"cosmos-server/pkg/model"
 	"cosmos-server/pkg/test"
 	"encoding/json"
+	"fmt"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -30,7 +31,6 @@ func TestHandleGetTeams(t *testing.T) {
 
 func TestHandleDeleteTeam(t *testing.T) {
 	t.Run("success - delete team", handleDeleteTeamSuccess)
-	t.Run("failure - team name is required", handleDeleteTeamNameRequiredFailure)
 	t.Run("failure - delete team with service error", handleDeleteTeamServiceError)
 }
 
@@ -330,7 +330,7 @@ func handleDeleteTeamSuccess(t *testing.T) {
 	mocks.loggerMock.EXPECT().
 		Infow(gomock.Any(), gomock.Any())
 
-	url := "/teams?name=" + teamName
+	url := fmt.Sprintf("/teams/%s", teamName)
 
 	request, recorder, err := test.NewHTTPRequest("DELETE", url, nil)
 	if err != nil {
@@ -340,30 +340,6 @@ func handleDeleteTeamSuccess(t *testing.T) {
 	router.ServeHTTP(recorder, request)
 
 	require.Equal(t, http.StatusNoContent, recorder.Code)
-}
-
-func handleDeleteTeamNameRequiredFailure(t *testing.T) {
-	router, mocks := setUp(t)
-
-	mocks.loggerMock.EXPECT().
-		Infow(gomock.Any(), gomock.Any())
-
-	url := "/teams"
-
-	request, recorder, err := test.NewHTTPRequest("DELETE", url, nil)
-	if err != nil {
-		t.Fatalf("Failed to create request: %v", err)
-	}
-
-	router.ServeHTTP(recorder, request)
-
-	actualResponse := &api.ErrorResponse{}
-	err = json.NewDecoder(recorder.Body).Decode(actualResponse)
-	if err != nil {
-		t.Fatalf("Failed to decode response: %v", err)
-	}
-
-	require.Equal(t, http.StatusBadRequest, recorder.Code)
 }
 
 func handleDeleteTeamServiceError(t *testing.T) {
@@ -379,7 +355,7 @@ func handleDeleteTeamServiceError(t *testing.T) {
 	mocks.loggerMock.EXPECT().
 		Infow(gomock.Any(), gomock.Any())
 
-	url := "/teams?name=" + teamName
+	url := fmt.Sprintf("/teams/%s", teamName)
 
 	request, recorder, err := test.NewHTTPRequest("DELETE", url, nil)
 	if err != nil {

--- a/pkg/routes/team/team_test.go
+++ b/pkg/routes/team/team_test.go
@@ -75,6 +75,7 @@ func setUp(t *testing.T) (*gin.Engine, *mocks) {
 
 	router := test.NewRouter(loggerMock)
 	AddAdminTeamHandler(router.Group("/"), teamServiceMock, NewTranslator())
+	AddAuthenticatedTeamHandler(router.Group("/"), teamServiceMock, NewTranslator())
 
 	return router, mocks
 }

--- a/pkg/routes/team/translator.go
+++ b/pkg/routes/team/translator.go
@@ -9,6 +9,7 @@ import (
 
 type Translator interface {
 	ToGetTeamsResponse(teams []*model.Team) *api.GetTeamsResponse
+	ToGetTeamResponse(team *model.Team) *api.GetTeamResponse
 	ToInsertTeamResponse(name, description string) *api.CreateTeamResponse
 	ToModelTeam(name, description string) *model.Team
 }
@@ -29,6 +30,15 @@ func (t *translator) ToGetTeamsResponse(teams []*model.Team) *api.GetTeamsRespon
 	}
 	return &api.GetTeamsResponse{
 		Teams: apiTeams,
+	}
+}
+
+func (t *translator) ToGetTeamResponse(team *model.Team) *api.GetTeamResponse {
+	return &api.GetTeamResponse{
+		Team: &api.Team{
+			Name:        team.Name,
+			Description: team.Description,
+		},
 	}
 }
 

--- a/pkg/routes/user/translator.go
+++ b/pkg/routes/user/translator.go
@@ -10,6 +10,7 @@ import (
 type Translator interface {
 	ToRegisterUserResponse(username, email, role string) *api.RegisterUserResponse
 	ToGetUsersResponse(users []*model.User) *api.GetUsersResponse
+	ToGetCurrentUserResponse(userModel *model.User) *api.GetCurrentUserResponse
 }
 
 type translator struct{}
@@ -47,5 +48,23 @@ func (t *translator) ToGetUsersResponse(users []*model.User) *api.GetUsersRespon
 	}
 	return &api.GetUsersResponse{
 		Users: apiUsers,
+	}
+}
+
+func (t *translator) ToGetCurrentUserResponse(userModel *model.User) *api.GetCurrentUserResponse {
+	var apiTeam *api.Team
+	if userModel.Team != nil {
+		apiTeam = &api.Team{
+			Name:        userModel.Team.Name,
+			Description: userModel.Team.Description,
+		}
+	}
+	return &api.GetCurrentUserResponse{
+		User: api.User{
+			Username: userModel.Username,
+			Email:    userModel.Email,
+			Role:     userModel.Role,
+			Team:     apiTeam,
+		},
 	}
 }

--- a/pkg/routes/user/user.go
+++ b/pkg/routes/user/user.go
@@ -26,9 +26,19 @@ func AddAdminUserHandler(e *gin.RouterGroup, userService user.Service, translato
 	usersGroup := e.Group("/users")
 
 	usersGroup.GET("", handler.handleGetUsers)
-	usersGroup.GET("/me", handler.handleGetCurrentUser)
 	usersGroup.POST("", handler.handleRegisterUser)
 	usersGroup.DELETE("", handler.handleDeleteUser)
+}
+
+func AddAuthenticatedUserHandler(e *gin.RouterGroup, userService user.Service, translator Translator, logger log.Logger) {
+	handler := &handler{
+		userService: userService,
+		translator:  translator,
+		logger:      logger,
+	}
+
+	usersGroup := e.Group("/users")
+	usersGroup.GET("/me", handler.handleGetCurrentUser)
 }
 
 func (handler *handler) handleRegisterUser(e *gin.Context) {

--- a/pkg/routes/user/user_test.go
+++ b/pkg/routes/user/user_test.go
@@ -77,6 +77,7 @@ func setUp(t *testing.T, mockedEmailForCtx string) (*gin.Engine, *mocks) {
 	}
 
 	AddAdminUserHandler(router.Group("/"), userServiceMock, translatorMock, loggerMock)
+	AddAuthenticatedUserHandler(router.Group("/"), userServiceMock, translatorMock, loggerMock)
 
 	return router, mocks
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -18,6 +18,11 @@ func NewGinHandler(routes *routes.HTTPRoutes) *gin.Engine {
 	unauthenticatedGroup := e.Group("/")
 	routes.RegisterUnauthenticatedRoutes(unauthenticatedGroup)
 
+	authenticatedGroup := e.Group("/",
+		middleware.AuthMiddleware(routes.AuthService),
+	)
+	routes.RegisterAuthenticatedRoutes(authenticatedGroup)
+
 	adminAuthenticatedGroup := e.Group("/",
 		middleware.AuthMiddleware(routes.AuthService),
 		middleware.AdminMiddleware(),

--- a/pkg/services/application/service.go
+++ b/pkg/services/application/service.go
@@ -10,6 +10,8 @@ import (
 	errorUtils "errors"
 )
 
+//go:generate mockgen -destination=./mock/service_mock.go -package=mock cosmos-server/pkg/services/application Service
+
 type Service interface {
 	AddApplication(ctx context.Context, name, description, team string) error
 	GetApplication(ctx context.Context, name string) (*model.Application, error)

--- a/pkg/services/application/service.go
+++ b/pkg/services/application/service.go
@@ -31,7 +31,7 @@ func NewApplicationService(storageService storage.Service, translator Translator
 }
 
 func (s *applicationService) AddApplication(ctx context.Context, name, description, team string) error {
-	serviceObj := &obj.Application{
+	applicationObj := &obj.Application{
 		Name:        name,
 		Description: description,
 	}
@@ -45,10 +45,10 @@ func (s *applicationService) AddApplication(ctx context.Context, name, descripti
 			return errors.NewInternalServerError("failed to retrieve team: " + err.Error())
 		}
 		teamIDInt := int(teamObj.ID)
-		serviceObj.TeamID = &teamIDInt
+		applicationObj.TeamID = &teamIDInt
 	}
 
-	err := s.storageService.InsertApplication(ctx, serviceObj)
+	err := s.storageService.InsertApplication(ctx, applicationObj)
 	if err != nil {
 		if errorUtils.Is(err, storage.ErrAlreadyExists) {
 			return errors.NewConflictError("application with name " + name + " already exists")

--- a/pkg/services/application/service.go
+++ b/pkg/services/application/service.go
@@ -13,6 +13,7 @@ import (
 type Service interface {
 	AddApplication(ctx context.Context, name, description, team string) error
 	GetApplication(ctx context.Context, name string) (*model.Application, error)
+	GetApplicationsWithFilter(ctx context.Context, filter string) ([]*model.Application, error)
 }
 
 type applicationService struct {
@@ -69,4 +70,13 @@ func (s *applicationService) GetApplication(ctx context.Context, name string) (*
 	}
 
 	return s.translator.ToApplicationModel(application), nil
+}
+
+func (s *applicationService) GetApplicationsWithFilter(ctx context.Context, filter string) ([]*model.Application, error) {
+	applications, err := s.storageService.GetApplicationsWithFilter(ctx, filter)
+	if err != nil {
+		return nil, errors.NewInternalServerError("failed to retrieve applications: " + err.Error())
+	}
+
+	return s.translator.ToApplicationModels(applications), nil
 }

--- a/pkg/services/application/service.go
+++ b/pkg/services/application/service.go
@@ -1,0 +1,58 @@
+package application
+
+import (
+	"context"
+	"cosmos-server/pkg/errors"
+	"cosmos-server/pkg/log"
+	"cosmos-server/pkg/storage"
+	"cosmos-server/pkg/storage/obj"
+	errorUtils "errors"
+)
+
+type Service interface {
+	AddApplication(ctx context.Context, name, description, team string) error
+}
+
+type applicationService struct {
+	storageService storage.Service
+	translator     Translator
+	logger         log.Logger
+}
+
+func NewApplicationService(storageService storage.Service, translator Translator, logger log.Logger) Service {
+	return &applicationService{
+		storageService: storageService,
+		translator:     translator,
+		logger:         logger,
+	}
+}
+
+func (s *applicationService) AddApplication(ctx context.Context, name, description, team string) error {
+	serviceObj := &obj.Application{
+		Name:        name,
+		Description: description,
+	}
+
+	if team != "" {
+		teamObj, err := s.storageService.GetTeamWithName(ctx, team)
+		if err != nil {
+			if errorUtils.Is(err, storage.ErrNotFound) {
+				return errors.NewNotFoundError("team not found")
+			}
+			return errors.NewInternalServerError("failed to retrieve team: " + err.Error())
+		}
+		teamIDInt := int(teamObj.ID)
+		serviceObj.TeamID = &teamIDInt
+	}
+
+	err := s.storageService.InsertApplication(ctx, serviceObj)
+	if err != nil {
+		if errorUtils.Is(err, storage.ErrAlreadyExists) {
+			return errors.NewConflictError("application with name " + name + " already exists")
+		}
+		return errors.NewInternalServerError("failed to insert application: " + err.Error())
+	}
+
+	s.logger.Infof("Application %s added successfully", name)
+	return nil
+}

--- a/pkg/services/application/service_test.go
+++ b/pkg/services/application/service_test.go
@@ -1,0 +1,72 @@
+package application
+
+import (
+	"context"
+	log "cosmos-server/pkg/log/mock"
+	storageMock "cosmos-server/pkg/storage/mock"
+	"cosmos-server/pkg/storage/obj"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"testing"
+)
+
+func TestAddApplication(t *testing.T) {
+	t.Run("add application - success", addApplicationSuccess)
+}
+
+type mocks struct {
+	controller         *gomock.Controller
+	storageServiceMock *storageMock.MockService
+	loggerMocks        *log.MockLogger
+}
+
+func setUp(t *testing.T) (Service, *mocks) {
+	ctrl := gomock.NewController(t)
+
+	mocks := &mocks{
+		controller:         ctrl,
+		storageServiceMock: storageMock.NewMockService(ctrl),
+		loggerMocks:        log.NewMockLogger(ctrl),
+	}
+
+	applicationService := NewApplicationService(mocks.storageServiceMock, NewTranslator(), mocks.loggerMocks)
+	return applicationService, mocks
+}
+
+func addApplicationSuccess(t *testing.T) {
+	applicationService, mocks := setUp(t)
+
+	applicationName := "test-application"
+	applicationDescription := "test-description"
+	applicationTeam := "test-team"
+
+	objTeam := &obj.Team{
+		CosmosObj: obj.CosmosObj{
+			ID: 1,
+		},
+		Name:        applicationName,
+		Description: applicationDescription,
+	}
+
+	teamID := int(objTeam.CosmosObj.ID)
+
+	applicationObj := &obj.Application{
+		Name:        applicationName,
+		Description: applicationDescription,
+		TeamID:      &teamID,
+	}
+
+	mocks.storageServiceMock.EXPECT().
+		GetTeamWithName(gomock.Any(), applicationTeam).
+		Return(objTeam, nil)
+
+	mocks.storageServiceMock.EXPECT().
+		InsertApplication(gomock.Any(), applicationObj).
+		Return(nil)
+
+	mocks.loggerMocks.EXPECT().
+		Infof(gomock.Any(), gomock.Any())
+
+	err := applicationService.AddApplication(context.Background(), applicationName, applicationDescription, applicationTeam)
+	require.NoError(t, err)
+}

--- a/pkg/services/application/service_test.go
+++ b/pkg/services/application/service_test.go
@@ -16,6 +16,7 @@ func TestAddApplication(t *testing.T) {
 	t.Run("add application - success", addApplicationSuccess)
 	t.Run("add application - no team success", addApplicationNoTeamSuccess)
 	t.Run("add application - invalid team error", addApplicationInvalidTeamError)
+	t.Run("add application - insert application error", addApplicationInsertApplicationError)
 }
 
 type mocks struct {
@@ -112,4 +113,40 @@ func addApplicationInvalidTeamError(t *testing.T) {
 	err := applicationService.AddApplication(context.Background(), applicationName, applicationDescription, applicationTeam)
 	require.Error(t, err)
 	require.True(t, strings.Contains(err.Error(), "team not found"))
+}
+
+func addApplicationInsertApplicationError(t *testing.T) {
+	applicationService, mocks := setUp(t)
+
+	applicationName := "test-application"
+	applicationDescription := "test-description"
+	applicationTeam := "test-team"
+
+	objTeam := &obj.Team{
+		CosmosObj: obj.CosmosObj{
+			ID: 1,
+		},
+		Name:        applicationName,
+		Description: applicationDescription,
+	}
+
+	teamID := int(objTeam.CosmosObj.ID)
+
+	applicationObj := &obj.Application{
+		Name:        applicationName,
+		Description: applicationDescription,
+		TeamID:      &teamID,
+	}
+
+	mocks.storageServiceMock.EXPECT().
+		GetTeamWithName(gomock.Any(), applicationTeam).
+		Return(objTeam, nil)
+
+	mocks.storageServiceMock.EXPECT().
+		InsertApplication(gomock.Any(), applicationObj).
+		Return(storage.ErrAlreadyExists)
+
+	err := applicationService.AddApplication(context.Background(), applicationName, applicationDescription, applicationTeam)
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), "application with name "+applicationName+" already exists"))
 }

--- a/pkg/services/application/translator.go
+++ b/pkg/services/application/translator.go
@@ -35,7 +35,7 @@ func (t *translator) ToModelTeam(teamObj *obj.Team) *model.Team {
 }
 
 func (t *translator) ToApplicationModels(applicationObjs []*obj.Application) []*model.Application {
-	var applicationModels []*model.Application
+	applicationModels := make([]*model.Application, 0, len(applicationObjs))
 	for _, applicationObj := range applicationObjs {
 		applicationModels = append(applicationModels, t.ToApplicationModel(applicationObj))
 	}

--- a/pkg/services/application/translator.go
+++ b/pkg/services/application/translator.go
@@ -7,6 +7,7 @@ import (
 
 type Translator interface {
 	ToApplicationModel(applicationObj *obj.Application) *model.Application
+	ToApplicationModels(applicationObjs []*obj.Application) []*model.Application
 }
 
 type translator struct{}
@@ -31,4 +32,12 @@ func (t *translator) ToModelTeam(teamObj *obj.Team) *model.Team {
 		Name:        teamObj.Name,
 		Description: teamObj.Description,
 	}
+}
+
+func (t *translator) ToApplicationModels(applicationObjs []*obj.Application) []*model.Application {
+	var applicationModels []*model.Application
+	for _, applicationObj := range applicationObjs {
+		applicationModels = append(applicationModels, t.ToApplicationModel(applicationObj))
+	}
+	return applicationModels
 }

--- a/pkg/services/application/translator.go
+++ b/pkg/services/application/translator.go
@@ -1,10 +1,34 @@
 package application
 
+import (
+	"cosmos-server/pkg/model"
+	"cosmos-server/pkg/storage/obj"
+)
+
 type Translator interface {
+	ToApplicationModel(applicationObj *obj.Application) *model.Application
 }
 
 type translator struct{}
 
 func NewTranslator() Translator {
 	return &translator{}
+}
+
+func (t *translator) ToApplicationModel(applicationObj *obj.Application) *model.Application {
+	return &model.Application{
+		Name:        applicationObj.Name,
+		Description: applicationObj.Description,
+		Team:        t.ToModelTeam(applicationObj.Team),
+	}
+}
+
+func (t *translator) ToModelTeam(teamObj *obj.Team) *model.Team {
+	if teamObj == nil {
+		return nil
+	}
+	return &model.Team{
+		Name:        teamObj.Name,
+		Description: teamObj.Description,
+	}
 }

--- a/pkg/services/application/translator.go
+++ b/pkg/services/application/translator.go
@@ -1,0 +1,10 @@
+package application
+
+type Translator interface {
+}
+
+type translator struct{}
+
+func NewTranslator() Translator {
+	return &translator{}
+}

--- a/pkg/storage/obj/application.go
+++ b/pkg/storage/obj/application.go
@@ -1,0 +1,9 @@
+package obj
+
+type Application struct {
+	CosmosObj
+	Name        string `gorm:"uniqueIndex"`
+	Description string
+	TeamID      *int
+	Team        *Team `gorm:"foreignKey:TeamID"`
+}

--- a/pkg/storage/postgresService.go
+++ b/pkg/storage/postgresService.go
@@ -42,7 +42,7 @@ func (s *PostgresService) InsertUser(ctx context.Context, user *obj.User) error 
 }
 
 func (s *PostgresService) GetUserWithEmail(ctx context.Context, email string) (*obj.User, error) {
-	user, err := gorm.G[obj.User](s.db).Where("email = ?", email).First(ctx)
+	user, err := gorm.G[obj.User](s.db).Preload("Team", nil).Where("email = ?", email).First(ctx)
 
 	if err != nil {
 		if errorUtils.Is(err, gorm.ErrRecordNotFound) {

--- a/pkg/storage/postgresService.go
+++ b/pkg/storage/postgresService.go
@@ -182,3 +182,15 @@ func (s *PostgresService) InsertApplication(ctx context.Context, application *ob
 
 	return nil
 }
+
+func (s *PostgresService) GetApplicationWithName(ctx context.Context, name string) (*obj.Application, error) {
+	application, err := gorm.G[*obj.Application](s.db).Preload("Team", nil).Where("name = ?", name).First(ctx)
+	if err != nil {
+		if errorUtils.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("failed to get application with name %s: %v", name, err)
+	}
+
+	return application, nil
+}

--- a/pkg/storage/postgresService.go
+++ b/pkg/storage/postgresService.go
@@ -203,3 +203,16 @@ func (s *PostgresService) GetApplicationsWithFilter(ctx context.Context, filter 
 
 	return applications, nil
 }
+
+func (s *PostgresService) DeleteApplicationWithName(ctx context.Context, name string) error {
+	rowsAffected, err := gorm.G[obj.Application](s.db).Where("name = ?", name).Delete(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to delete application with name %s: %v", name, err)
+	}
+
+	if rowsAffected == 0 {
+		return ErrNotFound
+	}
+
+	return nil
+}

--- a/pkg/storage/postgresService.go
+++ b/pkg/storage/postgresService.go
@@ -10,6 +10,7 @@ import (
 	_ "github.com/lib/pq"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
+	"strings"
 )
 
 type PostgresService struct {
@@ -81,7 +82,9 @@ func (s *PostgresService) GetUsersWithFilter(ctx context.Context, filter string)
 func (s *PostgresService) InsertTeam(ctx context.Context, team *obj.Team) error {
 	err := gorm.G[obj.Team](s.db).Create(ctx, team)
 	if err != nil {
-		if errorUtils.Is(err, gorm.ErrDuplicatedKey) {
+		if strings.Contains(err.Error(), "duplicate key") ||
+			strings.Contains(err.Error(), "violates unique constraint") ||
+			strings.Contains(err.Error(), "23505") {
 			return ErrAlreadyExists
 		}
 		return fmt.Errorf("failed to insert team: %v", err)

--- a/pkg/storage/postgresService.go
+++ b/pkg/storage/postgresService.go
@@ -170,3 +170,15 @@ func (s *PostgresService) GetTeamWithName(ctx context.Context, name string) (*ob
 
 	return team, nil
 }
+
+func (s *PostgresService) InsertApplication(ctx context.Context, application *obj.Application) error {
+	err := gorm.G[obj.Application](s.db).Create(ctx, application)
+	if err != nil {
+		if errorUtils.Is(err, gorm.ErrDuplicatedKey) {
+			return ErrAlreadyExists
+		}
+		return fmt.Errorf("failed to insert application: %v", err)
+	}
+
+	return nil
+}

--- a/pkg/storage/postgresService.go
+++ b/pkg/storage/postgresService.go
@@ -216,3 +216,17 @@ func (s *PostgresService) DeleteApplicationWithName(ctx context.Context, name st
 
 	return nil
 }
+
+func (s *PostgresService) GetApplicationsByTeam(ctx context.Context, team string) ([]*obj.Application, error) {
+	teamObj, err := s.GetTeamWithName(ctx, team)
+	if err != nil {
+		return nil, err
+	}
+
+	applications, err := gorm.G[*obj.Application](s.db).Preload("Team", nil).Where("team_id = ?", teamObj.ID).Order("name").Find(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get applications for team %s: %v", team, err)
+	}
+
+	return applications, nil
+}

--- a/pkg/storage/postgresService.go
+++ b/pkg/storage/postgresService.go
@@ -194,3 +194,12 @@ func (s *PostgresService) GetApplicationWithName(ctx context.Context, name strin
 
 	return application, nil
 }
+
+func (s *PostgresService) GetApplicationsWithFilter(ctx context.Context, filter string) ([]*obj.Application, error) {
+	applications, err := gorm.G[*obj.Application](s.db).Preload("Team", nil).Where("name ILIKE ?", "%"+filter+"%").Order("name").Find(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get applications with filter '%s': %v", filter, err)
+	}
+
+	return applications, nil
+}

--- a/pkg/storage/service.go
+++ b/pkg/storage/service.go
@@ -20,4 +20,6 @@ type Service interface {
 	GetTeamWithName(ctx context.Context, name string) (*obj.Team, error)
 	AddUserToTeam(ctx context.Context, teamName, username string) error
 	RemoveUserFromTeam(ctx context.Context, username string) error
+
+	InsertApplication(ctx context.Context, application *obj.Application) error
 }

--- a/pkg/storage/service.go
+++ b/pkg/storage/service.go
@@ -22,4 +22,5 @@ type Service interface {
 	RemoveUserFromTeam(ctx context.Context, username string) error
 
 	InsertApplication(ctx context.Context, application *obj.Application) error
+	GetApplicationWithName(ctx context.Context, name string) (*obj.Application, error)
 }

--- a/pkg/storage/service.go
+++ b/pkg/storage/service.go
@@ -24,4 +24,5 @@ type Service interface {
 	InsertApplication(ctx context.Context, application *obj.Application) error
 	GetApplicationWithName(ctx context.Context, name string) (*obj.Application, error)
 	GetApplicationsWithFilter(ctx context.Context, filter string) ([]*obj.Application, error)
+	DeleteApplicationWithName(ctx context.Context, name string) error
 }

--- a/pkg/storage/service.go
+++ b/pkg/storage/service.go
@@ -23,4 +23,5 @@ type Service interface {
 
 	InsertApplication(ctx context.Context, application *obj.Application) error
 	GetApplicationWithName(ctx context.Context, name string) (*obj.Application, error)
+	GetApplicationsWithFilter(ctx context.Context, filter string) ([]*obj.Application, error)
 }

--- a/pkg/storage/service.go
+++ b/pkg/storage/service.go
@@ -23,6 +23,7 @@ type Service interface {
 
 	InsertApplication(ctx context.Context, application *obj.Application) error
 	GetApplicationWithName(ctx context.Context, name string) (*obj.Application, error)
+	GetApplicationsByTeam(ctx context.Context, team string) ([]*obj.Application, error)
 	GetApplicationsWithFilter(ctx context.Context, filter string) ([]*obj.Application, error)
 	DeleteApplicationWithName(ctx context.Context, name string) error
 }


### PR DESCRIPTION
This pull request introduces a new "application" resource to the Cosmos server, including its API, database schema, service layer, and routing. It also improves the team API by adding endpoints for fetching a single team and standardizing HTTP status codes. The Makefile and documentation are updated for better development workflow and clarity.

**Application Resource Implementation:**

- Added new database migration to create the `applications` table, including indexes for efficient querying.
- Introduced `api/application.go` defining request/response structs and validation for the application API.
- Implemented the model, service, and translator for applications, enabling creation, retrieval, listing, and deletion of applications. 
- Registered application routes and service in the main app and route wiring, making the endpoints available to authenticated users.

**Team API Improvements:**

- Added endpoint to get a single team by name and corresponding response struct.
- Split team route registration into admin and authenticated user routes for better access control.
- Standardized HTTP status codes (e.g., using `http.StatusNoContent` and `http.StatusCreated`) for team endpoints.

**Testing and Documentation:**

- Added and updated tests for new team endpoints and behaviors.
- Updated `README.md` to reflect the new project structure and clarify the purpose of each directory.

**Developer Workflow:**

- Enhanced `Makefile` with targets for generating and cleaning mocks, streamlining testing and development.