### PR TITLE
SV-009: Add optional git repository to applications and u´date application route

### DIFF
--- a/api/application.go
+++ b/api/application.go
@@ -3,9 +3,17 @@ package api
 import validation "github.com/go-ozzo/ozzo-validation/v4"
 
 type CreateApplicationRequest struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	Team        string `json:"team,omitempty"`
+	Name           string          `json:"name"`
+	Description    string          `json:"description"`
+	Team           string          `json:"team,omitempty"`
+	GitInformation *GitInformation `json:"gitInformation,omitempty"`
+}
+
+type GitInformation struct {
+	Provider         string `json:"provider,omitempty"`
+	RepositoryOwner  string `json:"repositoryOwner,omitempty"`
+	RepositoryName   string `json:"repositoryName,omitempty"`
+	RepositoryBranch string `json:"repositoryBranch,omitempty"`
 }
 
 func (r *CreateApplicationRequest) Validate() error {
@@ -13,6 +21,20 @@ func (r *CreateApplicationRequest) Validate() error {
 		validation.Field(&r.Name, validation.Required, validation.Length(1, 100)),
 		validation.Field(&r.Description, validation.Length(0, 500)),
 		validation.Field(&r.Team, validation.Length(0, 100)),
+		validation.Field(&r.GitInformation, validation.When(r.GitInformation != nil,
+			validation.Required.Error("git information is required when provided"),
+			validation.By(func(value interface{}) error {
+				if gi, ok := value.(*GitInformation); ok && gi != nil {
+					return validation.ValidateStruct(gi,
+						validation.Field(&gi.Provider, validation.Required),
+						validation.Field(&gi.RepositoryOwner, validation.Required),
+						validation.Field(&gi.RepositoryName, validation.Required),
+						validation.Field(&gi.RepositoryBranch, validation.Required),
+					)
+				}
+				return nil
+			}),
+		)),
 	)
 }
 
@@ -21,9 +43,10 @@ type CreateApplicationResponse struct {
 }
 
 type Application struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	Team        *Team  `json:"team,omitempty"`
+	Name           string          `json:"name"`
+	Description    string          `json:"description"`
+	Team           *Team           `json:"team,omitempty"`
+	GitInformation *GitInformation `json:"gitInformation,omitempty"`
 }
 
 type GetApplicationResponse struct {

--- a/api/application.go
+++ b/api/application.go
@@ -56,3 +56,35 @@ type GetApplicationResponse struct {
 type GetApplicationsResponse struct {
 	Applications []*Application `json:"applications"`
 }
+
+type UpdateApplicationRequest struct {
+	Name           *string         `json:"name,omitempty"`
+	Description    *string         `json:"description,omitempty"`
+	Team           *string         `json:"team,omitempty"`
+	GitInformation *GitInformation `json:"gitInformation,omitempty"`
+}
+
+func (r *UpdateApplicationRequest) Validate() error {
+	return validation.ValidateStruct(r,
+		validation.Field(&r.Name, validation.When(r.Name != nil, validation.Length(1, 100))),
+		validation.Field(&r.Description, validation.When(r.Description != nil, validation.Length(0, 500))),
+		validation.Field(&r.Team, validation.When(r.Team != nil, validation.Length(0, 100))),
+		validation.Field(&r.GitInformation, validation.When(r.GitInformation != nil,
+			validation.By(func(value interface{}) error {
+				if gi, ok := value.(*GitInformation); ok && gi != nil {
+					return validation.ValidateStruct(gi,
+						validation.Field(&gi.Provider, validation.Required),
+						validation.Field(&gi.RepositoryOwner, validation.Required),
+						validation.Field(&gi.RepositoryName, validation.Required),
+						validation.Field(&gi.RepositoryBranch, validation.Required),
+					)
+				}
+				return nil
+			}),
+		)),
+	)
+}
+
+type UpdateApplicationResponse struct {
+	Application *Application `json:"application"`
+}

--- a/db/migrations/0004_add_git_information_to_application.down.sql
+++ b/db/migrations/0004_add_git_information_to_application.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE applications
+DROP COLUMN git_repository,
+DROP COLUMN git_branch;

--- a/db/migrations/0004_add_git_information_to_application.down.sql
+++ b/db/migrations/0004_add_git_information_to_application.down.sql
@@ -1,3 +1,5 @@
 ALTER TABLE applications
-DROP COLUMN git_repository,
-DROP COLUMN git_branch;
+DROP COLUMN IF EXISTS git_provider,
+DROP COLUMN IF EXISTS git_repository_owner,
+DROP COLUMN IF EXISTS git_repository_name,
+DROP COLUMN IF EXISTS git_repository_branch;

--- a/db/migrations/0004_add_git_information_to_application.up.sql
+++ b/db/migrations/0004_add_git_information_to_application.up.sql
@@ -1,3 +1,5 @@
 ALTER TABLE applications
-ADD COLUMN git_repository VARCHAR(500),
-ADD COLUMN git_branch VARCHAR(255);
+ADD COLUMN git_provider VARCHAR(100),
+ADD COLUMN git_repository_owner VARCHAR(255),
+ADD COLUMN git_repository_name VARCHAR(500),
+ADD COLUMN git_repository_branch VARCHAR(255);

--- a/db/migrations/0004_add_git_information_to_application.up.sql
+++ b/db/migrations/0004_add_git_information_to_application.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE applications
+ADD COLUMN git_repository VARCHAR(500),
+ADD COLUMN git_branch VARCHAR(255);

--- a/pkg/model/application.go
+++ b/pkg/model/application.go
@@ -13,3 +13,10 @@ type GitInformation struct {
 	RepositoryName   string
 	RepositoryBranch string
 }
+
+type ApplicationUpdate struct {
+	Name           *string
+	Description    *string
+	Team           *string
+	GitInformation *GitInformation
+}

--- a/pkg/model/application.go
+++ b/pkg/model/application.go
@@ -1,7 +1,15 @@
 package model
 
 type Application struct {
-	Name        string
-	Description string
-	Team        *Team
+	Name           string
+	Description    string
+	Team           *Team
+	GitInformation *GitInformation
+}
+
+type GitInformation struct {
+	Provider         string
+	RepositoryOwner  string
+	RepositoryName   string
+	RepositoryBranch string
 }

--- a/pkg/routes/application/application.go
+++ b/pkg/routes/application/application.go
@@ -4,6 +4,7 @@ import (
 	"cosmos-server/api"
 	"cosmos-server/pkg/errors"
 	"cosmos-server/pkg/log"
+	"cosmos-server/pkg/model"
 	"cosmos-server/pkg/services/application"
 	"fmt"
 	"github.com/gin-gonic/gin"
@@ -45,8 +46,17 @@ func (handler *handler) handleCreateApplication(e *gin.Context) {
 		_ = e.Error(errors.NewBadRequestError(err.Error()))
 		return
 	}
+	var gitInformation *model.GitInformation
+	if createApplicationRequest.GitInformation != nil {
+		gitInformation = &model.GitInformation{
+			Provider:         createApplicationRequest.GitInformation.Provider,
+			RepositoryOwner:  createApplicationRequest.GitInformation.RepositoryOwner,
+			RepositoryName:   createApplicationRequest.GitInformation.RepositoryName,
+			RepositoryBranch: createApplicationRequest.GitInformation.RepositoryBranch,
+		}
+	}
 
-	err := handler.applicationService.AddApplication(e, createApplicationRequest.Name, createApplicationRequest.Description, createApplicationRequest.Team)
+	err := handler.applicationService.AddApplication(e, createApplicationRequest.Name, createApplicationRequest.Description, createApplicationRequest.Team, gitInformation)
 	if err != nil {
 		_ = e.Error(err)
 		return

--- a/pkg/routes/application/application.go
+++ b/pkg/routes/application/application.go
@@ -30,6 +30,7 @@ func AddAuthenticatedApplicationHandler(e *gin.RouterGroup, applicationService a
 	applicationsGroup.GET("", handler.handleGetApplications)
 	applicationsGroup.GET("/team/:teamName", handler.handleGetApplicationByTeam)
 	applicationsGroup.POST("", handler.handleCreateApplication)
+	applicationsGroup.PUT("/:application", handler.handleUpdateApplication)
 	applicationsGroup.DELETE("/:application", handler.handleDeleteApplication)
 }
 
@@ -123,4 +124,47 @@ func (handler *handler) handleDeleteApplication(e *gin.Context) {
 	}
 
 	e.Status(http.StatusNoContent)
+}
+
+func (handler *handler) handleUpdateApplication(e *gin.Context) {
+	applicationName := e.Param("application")
+	if applicationName == "" {
+		_ = e.Error(errors.NewBadRequestError("application name missing"))
+		return
+	}
+
+	var updateRequest api.UpdateApplicationRequest
+	if err := e.ShouldBindJSON(&updateRequest); err != nil {
+		handler.logger.Errorf("Failed to bind JSON for update request: %v", err)
+		_ = e.Error(errors.NewBadRequestError(fmt.Sprintf("Invalid request format: %v", err)))
+		return
+	}
+
+	if err := updateRequest.Validate(); err != nil {
+		_ = e.Error(errors.NewBadRequestError(err.Error()))
+		return
+	}
+
+	updateData := &model.ApplicationUpdate{
+		Name:        updateRequest.Name,
+		Description: updateRequest.Description,
+		Team:        updateRequest.Team,
+	}
+
+	if updateRequest.GitInformation != nil {
+		updateData.GitInformation = &model.GitInformation{
+			Provider:         updateRequest.GitInformation.Provider,
+			RepositoryOwner:  updateRequest.GitInformation.RepositoryOwner,
+			RepositoryName:   updateRequest.GitInformation.RepositoryName,
+			RepositoryBranch: updateRequest.GitInformation.RepositoryBranch,
+		}
+	}
+
+	updatedApp, err := handler.applicationService.UpdateApplication(e, applicationName, updateData)
+	if err != nil {
+		_ = e.Error(err)
+		return
+	}
+
+	e.JSON(http.StatusOK, handler.translator.ToUpdateApplicationResponse(updatedApp))
 }

--- a/pkg/routes/application/application.go
+++ b/pkg/routes/application/application.go
@@ -62,7 +62,7 @@ func (handler *handler) handleCreateApplication(e *gin.Context) {
 		return
 	}
 
-	e.JSON(http.StatusCreated, handler.translator.ToCreateApplicationResponse(createApplicationRequest.Name, createApplicationRequest.Description, createApplicationRequest.Team))
+	e.JSON(http.StatusCreated, handler.translator.ToCreateApplicationResponse(createApplicationRequest.Name, createApplicationRequest.Description, createApplicationRequest.Team, gitInformation))
 }
 
 func (handler *handler) handleGetApplication(e *gin.Context) {

--- a/pkg/routes/application/application_test.go
+++ b/pkg/routes/application/application_test.go
@@ -92,7 +92,7 @@ func handleCreateApplicationSuccess(t *testing.T) {
 	}
 
 	mocks.applicationServiceMock.EXPECT().
-		AddApplication(gomock.Any(), mockedName, mockedDescription, mockedTeam).
+		AddApplication(gomock.Any(), mockedName, mockedDescription, mockedTeam, nil).
 		Return(nil)
 
 	mocks.loggerMock.EXPECT().
@@ -165,7 +165,7 @@ func handleCreateApplicationInsertApplicationError(t *testing.T) {
 	mockedError := errors.NewInternalServerError("Internal test error")
 
 	mocks.applicationServiceMock.EXPECT().
-		AddApplication(gomock.Any(), mockedName, mockedDescription, mockedTeam).
+		AddApplication(gomock.Any(), mockedName, mockedDescription, mockedTeam, nil).
 		Return(mockedError)
 
 	mocks.loggerMock.EXPECT().

--- a/pkg/routes/application/application_test.go
+++ b/pkg/routes/application/application_test.go
@@ -21,8 +21,17 @@ func TestHandleCreateApplication(t *testing.T) {
 	t.Run("failure - insert application error", handleCreateApplicationInsertApplicationError)
 }
 
+func TestHandleCreateApplicationWithGitInformation(t *testing.T) {
+	t.Run("success - create application with git information", handleCreateApplicationWithGitInformationSuccess)
+	t.Run("failure - git information provider required", handleCreateApplicationGitInformationProviderRequired)
+	t.Run("failure - git information repository owner required", handleCreateApplicationGitInformationRepositoryOwnerRequired)
+	t.Run("failure - git information repository name required", handleCreateApplicationGitInformationRepositoryNameRequired)
+	t.Run("failure - git information repository branch required", handleCreateApplicationGitInformationRepositoryBranchRequired)
+}
+
 func TestHandleGetApplication(t *testing.T) {
 	t.Run("success - get application", handleGetApplicationSuccess)
+	t.Run("success - get application with git information", handleGetApplicationWithGitInformationSuccess)
 	t.Run("failure - get application error", handleGetApplicationError)
 	t.Run("failure - get application error does not exist", handleGetApplicationErrorDoesNotExist)
 }
@@ -211,6 +220,66 @@ func handleGetApplicationSuccess(t *testing.T) {
 
 	expectedResponse := &api.GetApplicationResponse{
 		Application: mockedApplication,
+	}
+
+	mocks.applicationServiceMock.EXPECT().
+		GetApplication(gomock.Any(), mockedName).
+		Return(mockedApplicationModel, nil)
+
+	mocks.loggerMock.EXPECT().
+		Infow(gomock.Any(), gomock.Any())
+
+	url := "/applications/" + mockedName
+
+	request, recorder, err := test.NewHTTPRequest("GET", url, nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	router.ServeHTTP(recorder, request)
+
+	actualResponse := api.GetApplicationResponse{}
+	err = json.NewDecoder(recorder.Body).Decode(&actualResponse)
+	if err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	require.Equal(t, http.StatusOK, recorder.Code, "Expected status code 200")
+	require.Equal(t, expectedResponse, &actualResponse, "Response body mismatch")
+}
+
+func handleGetApplicationWithGitInformationSuccess(t *testing.T) {
+	router, mocks := setUp(t)
+
+	mockedName := "test-app"
+	mockedDescription := "Test application description"
+	mockedTeam := "test-team"
+	mockedGitInformation := &model.GitInformation{
+		Provider:         "github",
+		RepositoryOwner:  "test-owner",
+		RepositoryName:   "test-repo",
+		RepositoryBranch: "main",
+	}
+
+	mockedApplicationModel := &model.Application{
+		Name:           mockedName,
+		Description:    mockedDescription,
+		Team:           &model.Team{Name: mockedTeam},
+		GitInformation: mockedGitInformation,
+	}
+
+	expectedResponse := &api.GetApplicationResponse{
+		Application: &api.Application{
+			Name:        mockedName,
+			Description: mockedDescription,
+			Team:        &api.Team{Name: mockedTeam},
+			GitInformation: &api.GitInformation{
+				Provider:         "github",
+				RepositoryOwner:  "test-owner",
+				RepositoryName:   "test-repo",
+				RepositoryBranch: "main",
+			},
+		},
 	}
 
 	mocks.applicationServiceMock.EXPECT().
@@ -653,4 +722,230 @@ func handleGetApplicationByTeamNoApplications(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, recorder.Code, "Expected status code 200")
 	require.Equal(t, expectedResponse, &actualResponse, "Response body mismatch")
+}
+
+func handleCreateApplicationWithGitInformationSuccess(t *testing.T) {
+	router, mocks := setUp(t)
+
+	mockedName := "test-app"
+	mockedDescription := "Test application description"
+	mockedTeam := "test-team"
+	mockedGitInformation := &api.GitInformation{
+		Provider:         "github",
+		RepositoryOwner:  "test-owner",
+		RepositoryName:   "test-repo",
+		RepositoryBranch: "main",
+	}
+
+	mockedCreateApplicationRequest := &api.CreateApplicationRequest{
+		Name:           mockedName,
+		Description:    mockedDescription,
+		Team:           mockedTeam,
+		GitInformation: mockedGitInformation,
+	}
+
+	expectedResponse := &api.CreateApplicationResponse{
+		Application: &api.Application{
+			Name:           mockedName,
+			Description:    mockedDescription,
+			Team:           &api.Team{Name: mockedTeam},
+			GitInformation: mockedGitInformation,
+		},
+	}
+
+	expectedGitInfo := &model.GitInformation{
+		Provider:         "github",
+		RepositoryOwner:  "test-owner",
+		RepositoryName:   "test-repo",
+		RepositoryBranch: "main",
+	}
+
+	mocks.applicationServiceMock.EXPECT().
+		AddApplication(gomock.Any(), mockedName, mockedDescription, mockedTeam, expectedGitInfo).
+		Return(nil)
+
+	mocks.loggerMock.EXPECT().
+		Infow(gomock.Any(), gomock.Any())
+
+	url := "/applications"
+
+	request, recorder, err := test.NewHTTPRequest("POST", url, mockedCreateApplicationRequest)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	router.ServeHTTP(recorder, request)
+
+	actualResponse := api.CreateApplicationResponse{}
+	err = json.NewDecoder(recorder.Body).Decode(&actualResponse)
+	if err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	require.Equal(t, http.StatusCreated, recorder.Code, "Expected status code 201")
+	require.Equal(t, expectedResponse, &actualResponse, "Response body mismatch")
+}
+
+func handleCreateApplicationGitInformationProviderRequired(t *testing.T) {
+	router, mocks := setUp(t)
+
+	mockedName := "test-app"
+	mockedDescription := "Test application description"
+	mockedTeam := "test-team"
+	mockedGitInformation := &api.GitInformation{
+		RepositoryOwner:  "test-owner",
+		RepositoryName:   "test-repo",
+		RepositoryBranch: "main",
+	}
+
+	mockedCreateApplicationRequest := &api.CreateApplicationRequest{
+		Name:           mockedName,
+		Description:    mockedDescription,
+		Team:           mockedTeam,
+		GitInformation: mockedGitInformation,
+	}
+
+	mocks.loggerMock.EXPECT().
+		Infow(gomock.Any(), gomock.Any())
+
+	url := "/applications"
+
+	request, recorder, err := test.NewHTTPRequest("POST", url, mockedCreateApplicationRequest)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	router.ServeHTTP(recorder, request)
+
+	actualResponse := api.ErrorResponse{}
+	err = json.NewDecoder(recorder.Body).Decode(&actualResponse)
+	if err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	require.Equal(t, http.StatusBadRequest, recorder.Code, "Expected status code 400")
+	require.Contains(t, actualResponse.Error, "provider")
+}
+
+func handleCreateApplicationGitInformationRepositoryOwnerRequired(t *testing.T) {
+	router, mocks := setUp(t)
+
+	mockedName := "test-app"
+	mockedDescription := "Test application description"
+	mockedTeam := "test-team"
+	mockedGitInformation := &api.GitInformation{
+		Provider:         "github",
+		RepositoryName:   "test-repo",
+		RepositoryBranch: "main",
+	}
+
+	mockedCreateApplicationRequest := &api.CreateApplicationRequest{
+		Name:           mockedName,
+		Description:    mockedDescription,
+		Team:           mockedTeam,
+		GitInformation: mockedGitInformation,
+	}
+
+	mocks.loggerMock.EXPECT().
+		Infow(gomock.Any(), gomock.Any())
+
+	url := "/applications"
+
+	request, recorder, err := test.NewHTTPRequest("POST", url, mockedCreateApplicationRequest)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	router.ServeHTTP(recorder, request)
+
+	actualResponse := api.ErrorResponse{}
+	err = json.NewDecoder(recorder.Body).Decode(&actualResponse)
+	if err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	require.Equal(t, http.StatusBadRequest, recorder.Code, "Expected status code 400")
+	require.Contains(t, actualResponse.Error, "repositoryOwner")
+}
+
+func handleCreateApplicationGitInformationRepositoryNameRequired(t *testing.T) {
+	router, mocks := setUp(t)
+
+	mockedName := "test-app"
+	mockedDescription := "Test application description"
+	mockedTeam := "test-team"
+	mockedGitInformation := &api.GitInformation{
+		Provider:         "github",
+		RepositoryOwner:  "test-owner",
+		RepositoryBranch: "main",
+	}
+
+	mockedCreateApplicationRequest := &api.CreateApplicationRequest{
+		Name:           mockedName,
+		Description:    mockedDescription,
+		Team:           mockedTeam,
+		GitInformation: mockedGitInformation,
+	}
+
+	mocks.loggerMock.EXPECT().
+		Infow(gomock.Any(), gomock.Any())
+
+	url := "/applications"
+
+	request, recorder, err := test.NewHTTPRequest("POST", url, mockedCreateApplicationRequest)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	router.ServeHTTP(recorder, request)
+
+	actualResponse := api.ErrorResponse{}
+	err = json.NewDecoder(recorder.Body).Decode(&actualResponse)
+	if err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	require.Equal(t, http.StatusBadRequest, recorder.Code, "Expected status code 400")
+	require.Contains(t, actualResponse.Error, "repositoryName")
+}
+
+func handleCreateApplicationGitInformationRepositoryBranchRequired(t *testing.T) {
+	router, mocks := setUp(t)
+
+	mockedName := "test-app"
+	mockedDescription := "Test application description"
+	mockedTeam := "test-team"
+	mockedGitInformation := &api.GitInformation{
+		Provider:        "github",
+		RepositoryOwner: "test-owner",
+		RepositoryName:  "test-repo",
+	}
+
+	mockedCreateApplicationRequest := &api.CreateApplicationRequest{
+		Name:           mockedName,
+		Description:    mockedDescription,
+		Team:           mockedTeam,
+		GitInformation: mockedGitInformation,
+	}
+
+	mocks.loggerMock.EXPECT().
+		Infow(gomock.Any(), gomock.Any())
+
+	url := "/applications"
+
+	request, recorder, err := test.NewHTTPRequest("POST", url, mockedCreateApplicationRequest)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	router.ServeHTTP(recorder, request)
+
+	actualResponse := api.ErrorResponse{}
+	err = json.NewDecoder(recorder.Body).Decode(&actualResponse)
+	if err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	require.Equal(t, http.StatusBadRequest, recorder.Code, "Expected status code 400")
+	require.Contains(t, actualResponse.Error, "repositoryBranch")
 }

--- a/pkg/routes/application/translator.go
+++ b/pkg/routes/application/translator.go
@@ -9,6 +9,7 @@ type Translator interface {
 	ToCreateApplicationResponse(name, description, team string, gitInformation *model.GitInformation) *api.CreateApplicationResponse
 	ToGetApplicationResponse(applicationObj *model.Application) *api.GetApplicationResponse
 	ToGetApplicationsResponse(applicationObj []*model.Application) *api.GetApplicationsResponse
+	ToUpdateApplicationResponse(app *model.Application) *api.UpdateApplicationResponse
 }
 
 type translator struct{}
@@ -72,5 +73,11 @@ func (t *translator) ToApplicationApi(applicationModel *model.Application) *api.
 		Description:    applicationModel.Description,
 		Team:           t.ToApiTeam(applicationModel.Team),
 		GitInformation: t.ToApiGitInformation(applicationModel.GitInformation),
+	}
+}
+
+func (t *translator) ToUpdateApplicationResponse(app *model.Application) *api.UpdateApplicationResponse {
+	return &api.UpdateApplicationResponse{
+		Application: t.ToApplicationApi(app),
 	}
 }

--- a/pkg/routes/application/translator.go
+++ b/pkg/routes/application/translator.go
@@ -6,7 +6,7 @@ import (
 )
 
 type Translator interface {
-	ToCreateApplicationResponse(name, description, team string) *api.CreateApplicationResponse
+	ToCreateApplicationResponse(name, description, team string, gitInformation *model.GitInformation) *api.CreateApplicationResponse
 	ToGetApplicationResponse(applicationObj *model.Application) *api.GetApplicationResponse
 	ToGetApplicationsResponse(applicationObj []*model.Application) *api.GetApplicationsResponse
 }
@@ -17,12 +17,13 @@ func NewTranslator() Translator {
 	return &translator{}
 }
 
-func (t *translator) ToCreateApplicationResponse(name, description, team string) *api.CreateApplicationResponse {
+func (t *translator) ToCreateApplicationResponse(name, description, team string, gitInformation *model.GitInformation) *api.CreateApplicationResponse {
 	return &api.CreateApplicationResponse{
 		Application: &api.Application{
-			Name:        name,
-			Description: description,
-			Team:        &api.Team{Name: team},
+			Name:           name,
+			Description:    description,
+			Team:           &api.Team{Name: team},
+			GitInformation: t.ToApiGitInformation(gitInformation),
 		},
 	}
 }

--- a/pkg/routes/application/translator.go
+++ b/pkg/routes/application/translator.go
@@ -43,6 +43,18 @@ func (t *translator) ToApiTeam(teamModel *model.Team) *api.Team {
 	}
 }
 
+func (t *translator) ToApiGitInformation(gitInfo *model.GitInformation) *api.GitInformation {
+	if gitInfo == nil {
+		return nil
+	}
+	return &api.GitInformation{
+		Provider:         gitInfo.Provider,
+		RepositoryOwner:  gitInfo.RepositoryOwner,
+		RepositoryName:   gitInfo.RepositoryName,
+		RepositoryBranch: gitInfo.RepositoryBranch,
+	}
+}
+
 func (t *translator) ToGetApplicationsResponse(applicationModels []*model.Application) *api.GetApplicationsResponse {
 	applications := make([]*api.Application, 0)
 	for _, applicationModel := range applicationModels {
@@ -55,8 +67,9 @@ func (t *translator) ToGetApplicationsResponse(applicationModels []*model.Applic
 
 func (t *translator) ToApplicationApi(applicationModel *model.Application) *api.Application {
 	return &api.Application{
-		Name:        applicationModel.Name,
-		Description: applicationModel.Description,
-		Team:        t.ToApiTeam(applicationModel.Team),
+		Name:           applicationModel.Name,
+		Description:    applicationModel.Description,
+		Team:           t.ToApiTeam(applicationModel.Team),
+		GitInformation: t.ToApiGitInformation(applicationModel.GitInformation),
 	}
 }

--- a/pkg/services/application/service.go
+++ b/pkg/services/application/service.go
@@ -13,7 +13,7 @@ import (
 //go:generate mockgen -destination=./mock/service_mock.go -package=mock cosmos-server/pkg/services/application Service
 
 type Service interface {
-	AddApplication(ctx context.Context, name, description, team string) error
+	AddApplication(ctx context.Context, name, description, team string, gitInformation *model.GitInformation) error
 	GetApplication(ctx context.Context, name string) (*model.Application, error)
 	GetApplicationsByTeam(ctx context.Context, team string) ([]*model.Application, error)
 	GetApplicationsWithFilter(ctx context.Context, filter string) ([]*model.Application, error)
@@ -34,7 +34,7 @@ func NewApplicationService(storageService storage.Service, translator Translator
 	}
 }
 
-func (s *applicationService) AddApplication(ctx context.Context, name, description, team string) error {
+func (s *applicationService) AddApplication(ctx context.Context, name, description, team string, gitInformation *model.GitInformation) error {
 	applicationObj := &obj.Application{
 		Name:        name,
 		Description: description,
@@ -50,6 +50,13 @@ func (s *applicationService) AddApplication(ctx context.Context, name, descripti
 		}
 		teamIDInt := int(teamObj.ID)
 		applicationObj.TeamID = &teamIDInt
+	}
+
+	if gitInformation != nil {
+		applicationObj.GitProvider = gitInformation.Provider
+		applicationObj.GitRepositoryOwner = gitInformation.RepositoryOwner
+		applicationObj.GitRepositoryName = gitInformation.RepositoryName
+		applicationObj.GitRepositoryBranch = gitInformation.RepositoryBranch
 	}
 
 	err := s.storageService.InsertApplication(ctx, applicationObj)

--- a/pkg/services/application/service_test.go
+++ b/pkg/services/application/service_test.go
@@ -97,7 +97,7 @@ func addApplicationSuccess(t *testing.T) {
 	mocks.loggerMocks.EXPECT().
 		Infof(gomock.Any(), gomock.Any())
 
-	err := applicationService.AddApplication(context.Background(), applicationName, applicationDescription, applicationTeam)
+	err := applicationService.AddApplication(context.Background(), applicationName, applicationDescription, applicationTeam, nil)
 	require.NoError(t, err)
 }
 
@@ -120,7 +120,7 @@ func addApplicationNoTeamSuccess(t *testing.T) {
 	mocks.loggerMocks.EXPECT().
 		Infof(gomock.Any(), gomock.Any())
 
-	err := applicationService.AddApplication(context.Background(), applicationName, applicationDescription, applicationTeam)
+	err := applicationService.AddApplication(context.Background(), applicationName, applicationDescription, applicationTeam, nil)
 	require.NoError(t, err)
 }
 
@@ -135,7 +135,7 @@ func addApplicationInvalidTeamError(t *testing.T) {
 		GetTeamWithName(gomock.Any(), applicationTeam).
 		Return(nil, storage.ErrNotFound)
 
-	err := applicationService.AddApplication(context.Background(), applicationName, applicationDescription, applicationTeam)
+	err := applicationService.AddApplication(context.Background(), applicationName, applicationDescription, applicationTeam, nil)
 	require.Error(t, err)
 	require.True(t, strings.Contains(err.Error(), "team not found"))
 }
@@ -171,7 +171,7 @@ func addApplicationInsertApplicationError(t *testing.T) {
 		InsertApplication(gomock.Any(), applicationObj).
 		Return(storage.ErrAlreadyExists)
 
-	err := applicationService.AddApplication(context.Background(), applicationName, applicationDescription, applicationTeam)
+	err := applicationService.AddApplication(context.Background(), applicationName, applicationDescription, applicationTeam, nil)
 	require.Error(t, err)
 	require.True(t, strings.Contains(err.Error(), "application with name "+applicationName+" already exists"))
 }

--- a/pkg/services/application/translator.go
+++ b/pkg/services/application/translator.go
@@ -17,11 +17,22 @@ func NewTranslator() Translator {
 }
 
 func (t *translator) ToApplicationModel(applicationObj *obj.Application) *model.Application {
-	return &model.Application{
+	modelApplication := &model.Application{
 		Name:        applicationObj.Name,
 		Description: applicationObj.Description,
 		Team:        t.ToModelTeam(applicationObj.Team),
 	}
+
+	if applicationObj.GitProvider != "" || applicationObj.GitRepositoryName != "" || applicationObj.GitRepositoryOwner != "" || applicationObj.GitRepositoryBranch != "" {
+		modelApplication.GitInformation = &model.GitInformation{
+			Provider:         applicationObj.GitProvider,
+			RepositoryOwner:  applicationObj.GitRepositoryOwner,
+			RepositoryName:   applicationObj.GitRepositoryName,
+			RepositoryBranch: applicationObj.GitRepositoryBranch,
+		}
+	}
+
+	return modelApplication
 }
 
 func (t *translator) ToModelTeam(teamObj *obj.Team) *model.Team {

--- a/pkg/storage/obj/application.go
+++ b/pkg/storage/obj/application.go
@@ -2,8 +2,12 @@ package obj
 
 type Application struct {
 	CosmosObj
-	Name        string `gorm:"uniqueIndex"`
-	Description string
-	TeamID      *int
-	Team        *Team `gorm:"foreignKey:TeamID"`
+	Name                string `gorm:"uniqueIndex"`
+	Description         string
+	TeamID              *int
+	Team                *Team `gorm:"foreignKey:TeamID"`
+	GitProvider         string
+	GitRepositoryOwner  string
+	GitRepositoryName   string
+	GitRepositoryBranch string
 }

--- a/pkg/storage/postgresService.go
+++ b/pkg/storage/postgresService.go
@@ -233,3 +233,16 @@ func (s *PostgresService) GetApplicationsByTeam(ctx context.Context, team string
 
 	return applications, nil
 }
+
+func (s *PostgresService) UpdateApplication(ctx context.Context, application *obj.Application) error {
+	rowsAffected, err := gorm.G[*obj.Application](s.db).Where("id = ?", application.ID).Updates(ctx, application)
+	if err != nil {
+		return fmt.Errorf("failed to update application: %v", err)
+	}
+
+	if rowsAffected == 0 {
+		return ErrNotFound
+	}
+
+	return nil
+}

--- a/pkg/storage/service.go
+++ b/pkg/storage/service.go
@@ -26,4 +26,5 @@ type Service interface {
 	GetApplicationsByTeam(ctx context.Context, team string) ([]*obj.Application, error)
 	GetApplicationsWithFilter(ctx context.Context, filter string) ([]*obj.Application, error)
 	DeleteApplicationWithName(ctx context.Context, name string) error
+	UpdateApplication(ctx context.Context, application *obj.Application) error
 }


### PR DESCRIPTION
This pull request adds support for associating Git repository information with applications and introduces the ability to update application details, including Git information, via a new API endpoint. It includes changes to the API, data models, database schema, service layer, and HTTP routes to support these new capabilities.

**API and Model Enhancements:**

- Added a `GitInformation` struct to represent repository provider, owner, name, and branch, and included it in the `Application`, `CreateApplicationRequest`, and new `UpdateApplicationRequest` types. The validation logic ensures all Git fields are present if provided.
- Added the `UpdateApplicationRequest` and `UpdateApplicationResponse` types to support updating application details, including Git information.

**Database Schema Changes:**

- Added new columns to the `applications` table for storing Git provider, repository owner, name, and branch, with corresponding up and down migration scripts.
- Updated the storage model (`obj.Application`) to include Git information fields.

**Service and Business Logic:**

- Updated the service interface and implementation to handle Git information when creating or updating applications. Added a new `UpdateApplication` method that supports partial updates of application fields, including Git information and team assignment.
- Ensured translation between storage, model, and API layers includes Git information.

**HTTP Routing and Handlers:**

- Added a new `PUT /applications/:application` endpoint for updating applications. The handler processes the request, validates input, and returns the updated application.
- Modified the create application handler to accept and process Git information.

**Storage Layer:**

- Added an `UpdateApplication` method to the storage service and its Postgres implementation to persist application updates, including Git information.