### PR TITLE
SV-017: Create application groups

### DIFF
--- a/api/group.go
+++ b/api/group.go
@@ -1,0 +1,35 @@
+package api
+
+import validation "github.com/go-ozzo/ozzo-validation/v4"
+
+type CreateGroupRequest struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Members     []string `json:"members"`
+}
+
+func (r *CreateGroupRequest) Validate() error {
+	return validation.ValidateStruct(r,
+		validation.Field(&r.Name, validation.Required, validation.Length(1, 100)),
+		validation.Field(&r.Description, validation.Length(0, 500)),
+	)
+}
+
+type GetGroupsResponse struct {
+	Groups []*GroupReduced `json:"groups"`
+}
+
+type GroupReduced struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type Group struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	Members     []*Application `json:"members"`
+}
+
+type GetGroupResponse struct {
+	Group *Group `json:"group"`
+}

--- a/api/group.go
+++ b/api/group.go
@@ -33,3 +33,9 @@ type Group struct {
 type GetGroupResponse struct {
 	Group *Group `json:"group"`
 }
+
+type UpdateGroupRequest struct {
+	Name        *string  `json:"name"`
+	Description *string  `json:"description"`
+	Members     []string `json:"members"`
+}

--- a/db/migrations/0012_add_application_groups.down.sql
+++ b/db/migrations/0012_add_application_groups.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS group_applications;
+DROP TABLE IF EXISTS groups;

--- a/db/migrations/0012_add_application_groups.up.sql
+++ b/db/migrations/0012_add_application_groups.up.sql
@@ -1,0 +1,20 @@
+-- Create groups table
+CREATE TABLE IF NOT EXISTS groups (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL UNIQUE,
+    description TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Create join table for group-application relationships
+CREATE TABLE IF NOT EXISTS group_applications (
+    id SERIAL PRIMARY KEY,
+    group_id INTEGER NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+    application_id INTEGER NOT NULL REFERENCES applications(id) ON DELETE CASCADE,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (group_id, application_id)
+);
+
+CREATE INDEX group_applications_group_id_idx ON group_applications(group_id);
+CREATE INDEX group_applications_application_id_idx ON group_applications(application_id);

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -10,6 +10,7 @@ import (
 	"cosmos-server/pkg/server"
 	"cosmos-server/pkg/services/application"
 	"cosmos-server/pkg/services/auth"
+	"cosmos-server/pkg/services/group"
 	"cosmos-server/pkg/services/mail"
 	"cosmos-server/pkg/services/monitoring"
 	"cosmos-server/pkg/services/team"
@@ -49,10 +50,10 @@ func NewApp(config *c.Config) (*App, error) {
 	teamService := team.NewTeamService(storageService, team.NewTranslator())
 	applicationService := application.NewApplicationService(storageService, application.NewTranslator(), logger)
 	monitoringService := monitoring.NewMonitoringService(storageService, monitoring.NewGithubService(), monitoring.NewOpenApiService(), mailService, config.SentinelConfig.MaxIntervalSeconds, config.SentinelConfig.MinIntervalSeconds, encryptor, monitoring.NewTranslator(), logger)
-
 	tokenService := token.NewTokenService(encryptor, storageService, token.NewTranslator(), logger)
+	groupService := group.NewGroupService(storageService, group.NewTranslator(), logger)
 
-	httpRoutes := routes.NewHTTPRoutes(authService, userService, teamService, applicationService, monitoringService, tokenService, logger)
+	httpRoutes := routes.NewHTTPRoutes(authService, userService, teamService, applicationService, monitoringService, tokenService, groupService, logger)
 
 	return &App{
 		config: config,

--- a/pkg/model/group.go
+++ b/pkg/model/group.go
@@ -1,0 +1,7 @@
+package model
+
+type Group struct {
+	Name        string
+	Description string
+	Members     []*Application
+}

--- a/pkg/model/group.go
+++ b/pkg/model/group.go
@@ -5,3 +5,9 @@ type Group struct {
 	Description string
 	Members     []*Application
 }
+
+type GroupUpdate struct {
+	Name        *string
+	Description *string
+	Members     []string
+}

--- a/pkg/routes/group/group.go
+++ b/pkg/routes/group/group.go
@@ -29,6 +29,7 @@ func AddAuthenticatedGroupHandler(e *gin.RouterGroup, groupService group.Service
 	groupsGroup.POST("", handler.handleCreateGroup)
 	groupsGroup.GET("", handler.handleListGroups)
 	groupsGroup.GET("/:groupName", handler.handleGetGroup)
+	groupsGroup.DELETE("/:groupName", handler.handleDeleteGroup)
 }
 
 func (handler *handler) handleCreateGroup(e *gin.Context) {
@@ -74,4 +75,16 @@ func (handler *handler) handleGetGroup(e *gin.Context) {
 	}
 
 	e.JSON(http.StatusOK, handler.translator.ToGetGroupResponse(groupObj))
+}
+
+func (handler *handler) handleDeleteGroup(e *gin.Context) {
+	groupName := e.Param("groupName")
+
+	err := handler.groupService.DeleteGroup(e, groupName)
+	if err != nil {
+		_ = e.Error(err)
+		return
+	}
+
+	e.Status(http.StatusNoContent)
 }

--- a/pkg/routes/group/group.go
+++ b/pkg/routes/group/group.go
@@ -1,0 +1,77 @@
+package group
+
+import (
+	"cosmos-server/api"
+	"cosmos-server/pkg/errors"
+	"cosmos-server/pkg/log"
+	"cosmos-server/pkg/services/group"
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+type handler struct {
+	groupService group.Service
+	translator   Translator
+	logger       log.Logger
+}
+
+func AddAuthenticatedGroupHandler(e *gin.RouterGroup, groupService group.Service, translator Translator, logger log.Logger) {
+	handler := &handler{
+		groupService: groupService,
+		translator:   translator,
+		logger:       logger,
+	}
+
+	groupsGroup := e.Group("/groups")
+
+	groupsGroup.POST("", handler.handleCreateGroup)
+	groupsGroup.GET("", handler.handleListGroups)
+	groupsGroup.GET("/:groupName", handler.handleGetGroup)
+}
+
+func (handler *handler) handleCreateGroup(e *gin.Context) {
+	var createGroupRequest api.CreateGroupRequest
+	if err := e.ShouldBindJSON(&createGroupRequest); err != nil {
+		handler.logger.Errorf("Failed to bind JSON for create group request: %v", err)
+		_ = e.Error(err)
+		return
+	}
+
+	err := createGroupRequest.Validate()
+	if err != nil {
+		_ = e.Error(errors.NewBadRequestError(fmt.Sprintf("Invalid request format: %v", err)))
+		return
+	}
+
+	err = handler.groupService.CreateGroup(e, createGroupRequest.Name, createGroupRequest.Description, createGroupRequest.Members)
+	if err != nil {
+		_ = e.Error(err)
+		return
+	}
+
+	e.Status(http.StatusCreated)
+}
+
+func (handler *handler) handleListGroups(e *gin.Context) {
+	groups, err := handler.groupService.GetAllGroups(e)
+	if err != nil {
+		_ = e.Error(err)
+		return
+	}
+
+	e.JSON(http.StatusOK, handler.translator.ToGetGroupsResponse(groups))
+}
+
+func (handler *handler) handleGetGroup(e *gin.Context) {
+	groupName := e.Param("groupName")
+
+	groupObj, err := handler.groupService.GetGroupByName(e, groupName)
+	if err != nil {
+		_ = e.Error(err)
+		return
+	}
+
+	e.JSON(http.StatusOK, handler.translator.ToGetGroupResponse(groupObj))
+}

--- a/pkg/routes/group/translator.go
+++ b/pkg/routes/group/translator.go
@@ -1,0 +1,120 @@
+package group
+
+import (
+	"cosmos-server/api"
+	"cosmos-server/pkg/model"
+)
+
+type Translator interface {
+	ToGetGroupsResponse(modelGroups []*model.Group) api.GetGroupsResponse
+	ToGetGroupResponse(modelGroup *model.Group) api.GetGroupResponse
+}
+
+type translator struct {
+}
+
+func NewTranslator() Translator {
+	return &translator{}
+}
+
+func (t *translator) ToGetGroupsResponse(modelGroups []*model.Group) api.GetGroupsResponse {
+	apiReducedGroups := make([]*api.GroupReduced, 0, len(modelGroups))
+
+	for _, modelGroup := range modelGroups {
+		apiReducedGroup := api.GroupReduced{
+			Name:        modelGroup.Name,
+			Description: modelGroup.Description,
+		}
+		apiReducedGroups = append(apiReducedGroups, &apiReducedGroup)
+	}
+
+	return api.GetGroupsResponse{
+		Groups: apiReducedGroups,
+	}
+}
+
+func (t *translator) ToGetGroupResponse(modelGroup *model.Group) api.GetGroupResponse {
+	if modelGroup == nil {
+		return api.GetGroupResponse{}
+	}
+
+	return api.GetGroupResponse{
+		Group: &api.Group{
+			Name:        modelGroup.Name,
+			Description: modelGroup.Description,
+			Members:     t.ToGetApplicationsApi(modelGroup.Members),
+		},
+	}
+}
+
+func (t *translator) ToGetApplicationsApi(modelApplications []*model.Application) []*api.Application {
+	apiApplications := make([]*api.Application, 0, len(modelApplications))
+
+	for _, modelApplication := range modelApplications {
+		apiApplications = append(apiApplications, t.ToApplicationApi(modelApplication))
+	}
+
+	return apiApplications
+}
+
+func (t *translator) ToApplicationApi(applicationModel *model.Application) *api.Application {
+	return &api.Application{
+		Name:                  applicationModel.Name,
+		Description:           applicationModel.Description,
+		Team:                  t.ToApiTeam(applicationModel.Team),
+		GitInformation:        t.ToApiGitInformation(applicationModel.GitInformation),
+		MonitoringInformation: t.ToMonitoringInformationApi(applicationModel.MonitoringInformation),
+		Token:                 t.ToTokenApi(applicationModel.Token),
+	}
+}
+
+func (t *translator) ToMonitoringInformationApi(monitoringInfo *model.MonitoringInformation) *api.MonitoringInformation {
+	if monitoringInfo == nil {
+		return nil
+	}
+
+	return &api.MonitoringInformation{
+		HasOpenAPI:     monitoringInfo.HasOpenApi,
+		OpenAPIPath:    monitoringInfo.OpenApiPath,
+		HasOpenClient:  monitoringInfo.HasOpenClient,
+		OpenClientPath: monitoringInfo.OpenClientPath,
+	}
+}
+
+func (t *translator) ToApiGitInformation(gitInfo *model.GitInformation) *api.GitInformation {
+	if gitInfo == nil {
+		return nil
+	}
+	return &api.GitInformation{
+		Provider:         gitInfo.Provider,
+		RepositoryOwner:  gitInfo.RepositoryOwner,
+		RepositoryName:   gitInfo.RepositoryName,
+		RepositoryBranch: gitInfo.RepositoryBranch,
+	}
+}
+
+func (t *translator) ToApiTeam(teamModel *model.Team) *api.Team {
+	if teamModel == nil {
+		return nil
+	}
+	return &api.Team{
+		Name:        teamModel.Name,
+		Description: teamModel.Description,
+	}
+}
+
+func (t *translator) ToTokenApi(tokenModel *model.Token) *api.Token {
+	if tokenModel == nil {
+		return nil
+	}
+
+	team := ""
+	if tokenModel.Team != nil {
+		team = tokenModel.Team.Name
+	}
+
+	return &api.Token{
+		Name: tokenModel.Name,
+		Team: team,
+	}
+}

--- a/pkg/routes/monitoring/monitoring.go
+++ b/pkg/routes/monitoring/monitoring.go
@@ -34,6 +34,7 @@ func AddAuthenticatedMonitoringHandler(e *gin.RouterGroup, monitoringService mon
 	monitoringGroup.POST("/update/:application", handler.handleUpdateApplicationMonitoring)
 	monitoringGroup.GET("/interactions/:application", handler.handleGetApplicationInteractions)
 	monitoringGroup.GET("/interactions", handler.handleGetApplicationsInteractions)
+	monitoringGroup.GET("/interactions/group/:group", handler.handleGetGroupApplicationsInteractions)
 	monitoringGroup.GET("/openapi/:application", handler.handleGetApplicationOpenAPISpecification)
 	monitoringGroup.GET("/complete/:application", handler.handleGetCompleteApplicationMonitoring)
 }
@@ -211,4 +212,17 @@ func (handler *handler) handleGetSentinelConfiguration(e *gin.Context) {
 	}
 
 	e.JSON(200, handler.translator.ToGetSentinelSettingsResponse(settings))
+}
+
+func (handler *handler) handleGetGroupApplicationsInteractions(e *gin.Context) {
+	groupName := e.Param("group")
+
+	interactions, err := handler.monitoringService.GetGroupApplicationsInteractions(e, groupName)
+	if err != nil {
+		handler.logger.Errorf("Failed to retrieve group applications interactions: %v", err)
+		_ = e.Error(err)
+		return
+	}
+
+	e.JSON(200, handler.translator.ToGetApplicationsInteractionsResponse(interactions))
 }

--- a/pkg/routes/routes.go
+++ b/pkg/routes/routes.go
@@ -5,6 +5,7 @@ import (
 	monitoringRoute "cosmos-server/pkg/routes/monitoring"
 	"cosmos-server/pkg/services/application"
 	"cosmos-server/pkg/services/auth"
+	"cosmos-server/pkg/services/group"
 	"cosmos-server/pkg/services/monitoring"
 	"cosmos-server/pkg/services/team"
 	"cosmos-server/pkg/services/token"
@@ -14,6 +15,7 @@ import (
 
 	applicationRoute "cosmos-server/pkg/routes/application"
 	authRoute "cosmos-server/pkg/routes/auth"
+	groupRoute "cosmos-server/pkg/routes/group"
 	healthcheckRoute "cosmos-server/pkg/routes/healthcheck"
 	teamRoute "cosmos-server/pkg/routes/team"
 	tokenRoute "cosmos-server/pkg/routes/token"
@@ -27,10 +29,11 @@ type HTTPRoutes struct {
 	ApplicationService application.Service
 	MonitoringService  monitoring.Service
 	TokenService       token.Service
+	GroupService       group.Service
 	Logger             log.Logger
 }
 
-func NewHTTPRoutes(authService auth.Service, userService user.Service, teamService team.Service, applicationService application.Service, monitoringService monitoring.Service, tokenService token.Service, logger log.Logger) *HTTPRoutes {
+func NewHTTPRoutes(authService auth.Service, userService user.Service, teamService team.Service, applicationService application.Service, monitoringService monitoring.Service, tokenService token.Service, groupService group.Service, logger log.Logger) *HTTPRoutes {
 	return &HTTPRoutes{
 		AuthService:        authService,
 		UserService:        userService,
@@ -38,6 +41,7 @@ func NewHTTPRoutes(authService auth.Service, userService user.Service, teamServi
 		ApplicationService: applicationService,
 		MonitoringService:  monitoringService,
 		TokenService:       tokenService,
+		GroupService:       groupService,
 		Logger:             logger,
 	}
 }
@@ -53,6 +57,7 @@ func (r *HTTPRoutes) RegisterAuthenticatedRoutes(e *gin.RouterGroup) {
 	teamRoute.AddAuthenticatedTeamHandler(e, r.TeamService, teamRoute.NewTranslator())
 	monitoringRoute.AddAuthenticatedMonitoringHandler(e, r.MonitoringService, r.ApplicationService, monitoringRoute.NewTranslator(), r.Logger)
 	tokenRoute.AddAuthenticatedTokenHandler(e, r.TokenService, r.UserService, tokenRoute.NewTranslator(), r.Logger)
+	groupRoute.AddAuthenticatedGroupHandler(e, r.GroupService, groupRoute.NewTranslator(), r.Logger)
 }
 
 func (r *HTTPRoutes) RegisterAdminAuthenticatedRoutes(e *gin.RouterGroup) {

--- a/pkg/services/group/service.go
+++ b/pkg/services/group/service.go
@@ -1,0 +1,78 @@
+package group
+
+import (
+	"context"
+	"cosmos-server/pkg/errors"
+	"cosmos-server/pkg/log"
+	"cosmos-server/pkg/model"
+	"cosmos-server/pkg/storage"
+	"cosmos-server/pkg/storage/obj"
+	errorUtils "errors"
+	"fmt"
+)
+
+type Service interface {
+	CreateGroup(ctx context.Context, name, description string, members []string) error
+	GetAllGroups(ctx context.Context) ([]*model.Group, error)
+	GetGroupByName(ctx context.Context, name string) (*model.Group, error)
+}
+
+type groupService struct {
+	storageService storage.Service
+	translator     Translator
+	logger         log.Logger
+}
+
+func NewGroupService(storageService storage.Service, translator Translator, logger log.Logger) Service {
+	return &groupService{
+		storageService: storageService,
+		translator:     translator,
+		logger:         logger,
+	}
+}
+
+func (s *groupService) CreateGroup(ctx context.Context, name, description string, members []string) error {
+	applications := make([]*obj.Application, 0)
+
+	for _, member := range members {
+		applicationObj, err := s.storageService.GetApplicationWithName(ctx, member)
+		if err != nil {
+			if errorUtils.Is(err, storage.ErrNotFound) {
+				return errors.NewNotFoundError(fmt.Sprintf("application %s not found", member))
+			}
+			s.logger.Errorf("Failed to retrieve application %s: %v", member, err)
+			return fmt.Errorf("failed to retrieve application %s: %v", member, err)
+		}
+		applications = append(applications, applicationObj)
+	}
+
+	err := s.storageService.CreateGroup(ctx, name, description, applications)
+	if err != nil {
+		s.logger.Errorf("Failed to create group: %v", err)
+		return err
+	}
+	return nil
+}
+
+func (s *groupService) GetAllGroups(ctx context.Context) ([]*model.Group, error) {
+	groupsObj, err := s.storageService.GetGroups(ctx)
+	if err != nil {
+		s.logger.Errorf("Failed to retrieve groups: %v", err)
+		return nil, fmt.Errorf("failed to retrieve groups: %v", err)
+	}
+
+	return s.translator.ToGroupModels(groupsObj), nil
+}
+
+func (s *groupService) GetGroupByName(ctx context.Context, name string) (*model.Group, error) {
+	groupObj, err := s.storageService.GetGroupByName(ctx, name)
+	if err != nil {
+		if errorUtils.Is(err, storage.ErrNotFound) {
+			return nil, errors.NewNotFoundError(fmt.Sprintf("group %s not found", name))
+		}
+		s.logger.Errorf("Failed to retrieve group %s: %v", name, err)
+		return nil, fmt.Errorf("failed to retrieve group %s: %v", name, err)
+	}
+
+	return s.translator.ToGroupModel(groupObj), nil
+}

--- a/pkg/services/group/service.go
+++ b/pkg/services/group/service.go
@@ -15,6 +15,7 @@ type Service interface {
 	CreateGroup(ctx context.Context, name, description string, members []string) error
 	GetAllGroups(ctx context.Context) ([]*model.Group, error)
 	GetGroupByName(ctx context.Context, name string) (*model.Group, error)
+	DeleteGroup(ctx context.Context, name string) error
 }
 
 type groupService struct {
@@ -75,4 +76,16 @@ func (s *groupService) GetGroupByName(ctx context.Context, name string) (*model.
 	}
 
 	return s.translator.ToGroupModel(groupObj), nil
+}
+
+func (s *groupService) DeleteGroup(ctx context.Context, name string) error {
+	err := s.storageService.DeleteGroupByName(ctx, name)
+	if err != nil {
+		if errorUtils.Is(err, storage.ErrNotFound) {
+			return errors.NewNotFoundError(fmt.Sprintf("group %s not found", name))
+		}
+		s.logger.Errorf("Failed to delete group %s: %v", name, err)
+		return fmt.Errorf("failed to delete group %s: %v", name, err)
+	}
+	return nil
 }

--- a/pkg/services/group/translator.go
+++ b/pkg/services/group/translator.go
@@ -1,0 +1,104 @@
+package group
+
+import (
+	"cosmos-server/pkg/model"
+	"cosmos-server/pkg/storage/obj"
+)
+
+type Translator interface {
+	ToGroupModels(groupsObj []*obj.Group) []*model.Group
+	ToGroupModel(group *obj.Group) *model.Group
+}
+
+type translator struct {
+}
+
+func NewTranslator() Translator {
+	return &translator{}
+}
+
+func (t *translator) ToGroupModels(groupsObj []*obj.Group) []*model.Group {
+	groups := make([]*model.Group, 0)
+
+	for _, groupObj := range groupsObj {
+		groups = append(groups, t.ToGroupModel(groupObj))
+	}
+
+	return groups
+}
+
+func (t *translator) ToGroupModel(groupObj *obj.Group) *model.Group {
+	group := &model.Group{
+		Name:        groupObj.Name,
+		Description: groupObj.Description,
+		Members:     t.ToApplicationModels(groupObj.Applications),
+	}
+
+	return group
+}
+
+func (t *translator) ToApplicationModel(applicationObj *obj.Application) *model.Application {
+	modelApplication := &model.Application{
+		Name:                  applicationObj.Name,
+		Description:           applicationObj.Description,
+		Team:                  t.ToModelTeam(applicationObj.Team),
+		MonitoringInformation: t.ToModelMonitoringInformation(applicationObj),
+		Token:                 t.ToModelToken(applicationObj.Token),
+	}
+
+	if applicationObj.GitProvider != "" || applicationObj.GitRepositoryName != "" || applicationObj.GitRepositoryOwner != "" || applicationObj.GitRepositoryBranch != "" {
+		modelApplication.GitInformation = &model.GitInformation{
+			Provider:         applicationObj.GitProvider,
+			RepositoryOwner:  applicationObj.GitRepositoryOwner,
+			RepositoryName:   applicationObj.GitRepositoryName,
+			RepositoryBranch: applicationObj.GitRepositoryBranch,
+		}
+	}
+
+	return modelApplication
+}
+
+func (t *translator) ToModelTeam(teamObj *obj.Team) *model.Team {
+	if teamObj == nil {
+		return nil
+	}
+	return &model.Team{
+		Name:        teamObj.Name,
+		Description: teamObj.Description,
+	}
+}
+
+func (t *translator) ToApplicationModels(applicationObjs []*obj.Application) []*model.Application {
+	applicationModels := make([]*model.Application, 0, len(applicationObjs))
+	for _, applicationObj := range applicationObjs {
+		applicationModels = append(applicationModels, t.ToApplicationModel(applicationObj))
+	}
+	return applicationModels
+}
+
+func (t *translator) ToModelMonitoringInformation(applicationObj *obj.Application) *model.MonitoringInformation {
+	if applicationObj == nil {
+		return nil
+	}
+
+	return &model.MonitoringInformation{
+		DependenciesSha: applicationObj.DependenciesSha,
+		OpenAPISha:      applicationObj.OpenAPISha,
+		HasOpenApi:      applicationObj.HasOpenApi,
+		OpenApiPath:     applicationObj.OpenApiPath,
+		HasOpenClient:   applicationObj.HasOpenClient,
+		OpenClientPath:  applicationObj.OpenClientPath,
+	}
+}
+
+func (t *translator) ToModelToken(tokenObj *obj.Token) *model.Token {
+	if tokenObj == nil {
+		return nil
+	}
+
+	return &model.Token{
+		Name:           tokenObj.Name,
+		EncryptedValue: tokenObj.EncryptedValue,
+		Team:           t.ToModelTeam(tokenObj.Team),
+	}
+}

--- a/pkg/storage/obj/group.go
+++ b/pkg/storage/obj/group.go
@@ -1,0 +1,8 @@
+package obj
+
+type Group struct {
+	CosmosObj
+	Name         string `gorm:"uniqueIndex"`
+	Description  string
+	Applications []*Application `gorm:"many2many:group_applications;"`
+}

--- a/pkg/storage/postgresService.go
+++ b/pkg/storage/postgresService.go
@@ -819,3 +819,16 @@ func (s *PostgresService) GetApplicationDependenciesFromGroup(ctx context.Contex
 
 	return dependencies, nil
 }
+
+func (s *PostgresService) DeleteGroupByName(ctx context.Context, name string) error {
+	rowsAffected, err := gorm.G[obj.Group](s.db).Where("name = ?", name).Delete(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to delete group %s: %v", name, err)
+	}
+
+	if rowsAffected == 0 {
+		return ErrNotFound
+	}
+
+	return nil
+}

--- a/pkg/storage/postgresService.go
+++ b/pkg/storage/postgresService.go
@@ -833,19 +833,6 @@ func (s *PostgresService) DeleteGroupByName(ctx context.Context, name string) er
 	return nil
 }
 
-//func (s *PostgresService) UpdateGroup(ctx context.Context, group *obj.Group) error {
-//	rowsAffected, err := gorm.G[*obj.Group](s.db).Where("id = ?", group.ID).Select("*").Updates(ctx, group)
-//	if err != nil {
-//		return fmt.Errorf("failed to update group: %v", err)
-//	}
-//
-//	if rowsAffected == 0 {
-//		return ErrNotFound
-//	}
-//
-//	return nil
-//}
-
 func (s *PostgresService) UpdateGroup(ctx context.Context, group *obj.Group) error {
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		rowsAffected, err := gorm.G[*obj.Group](tx).Where("id = ?", group.ID).Select("*").Updates(ctx, group)

--- a/pkg/storage/postgresService.go
+++ b/pkg/storage/postgresService.go
@@ -767,9 +767,12 @@ func (s *PostgresService) CreateGroup(ctx context.Context, name, description str
 
 	err := gorm.G[obj.Group](s.db).Create(ctx, group)
 	if err != nil {
-		if errorUtils.Is(err, gorm.ErrDuplicatedKey) {
+		if strings.Contains(err.Error(), "duplicate key") {
 			return ErrAlreadyExists
 		}
+		//if errorUtils.Is(err, gorm.ErrDuplicatedKey) {
+		//	return ErrAlreadyExists
+		//}
 		return fmt.Errorf("failed to create group: %v", err)
 	}
 

--- a/pkg/storage/service.go
+++ b/pkg/storage/service.go
@@ -58,4 +58,5 @@ type Service interface {
 	GetGroups(ctx context.Context) ([]*obj.Group, error)
 	GetGroupByName(ctx context.Context, name string) (*obj.Group, error)
 	DeleteGroupByName(ctx context.Context, name string) error
+	UpdateGroup(ctx context.Context, group *obj.Group) error
 }

--- a/pkg/storage/service.go
+++ b/pkg/storage/service.go
@@ -35,6 +35,7 @@ type Service interface {
 	GetApplicationDependenciesWithFilter(ctx context.Context, filters model.ApplicationDependencyFilter) ([]*obj.ApplicationDependency, error)
 	GetApplicationDependenciesByConsumer(ctx context.Context, consumerName string) ([]*obj.ApplicationDependency, error)
 	GetApplicationDependenciesByProvider(ctx context.Context, providerName string) ([]*obj.ApplicationDependency, error)
+	GetApplicationDependenciesFromGroup(ctx context.Context, group *obj.Group) ([]*obj.ApplicationDependency, error)
 
 	UpsertOpenAPISpecification(ctx context.Context, applicationName string, openAPISpec *obj.ApplicationOpenAPI, applicationOpenApiSHA string) error
 	UpdateApplicationDependencies(ctx context.Context, applicationName string, dependenciesToUpsert map[string]*obj.ApplicationDependency, pendingDependencies map[string]*obj.PendingApplicationDependency, dependenciesToDelete []*obj.ApplicationDependency, applicationDependenciesSHA string) error
@@ -52,4 +53,8 @@ type Service interface {
 	GetAllTokens(ctx context.Context) ([]*obj.Token, error)
 	DeleteToken(ctx context.Context, name string, team string) error
 	UpdateToken(ctx context.Context, token *obj.Token) error
+
+	CreateGroup(ctx context.Context, name, description string, applications []*obj.Application) error
+	GetGroups(ctx context.Context) ([]*obj.Group, error)
+	GetGroupByName(ctx context.Context, name string) (*obj.Group, error)
 }

--- a/pkg/storage/service.go
+++ b/pkg/storage/service.go
@@ -57,4 +57,5 @@ type Service interface {
 	CreateGroup(ctx context.Context, name, description string, applications []*obj.Application) error
 	GetGroups(ctx context.Context) ([]*obj.Group, error)
 	GetGroupByName(ctx context.Context, name string) (*obj.Group, error)
+	DeleteGroupByName(ctx context.Context, name string) error
 }


### PR DESCRIPTION
This pull request introduces a new "group" feature to the codebase, allowing applications to be organized into groups with CRUD (Create, Read, Update, Delete) operations and associated API endpoints. It includes database schema changes, new service and model layers, HTTP routes, and request/response translations for the group functionality.

**New Group Feature Implementation:**

* **Database Schema:**
  - Adds new `groups` and `group_applications` tables to support group entities and their many-to-many relationship with applications.
  - Provides a migration for dropping these tables if needed.

* **API Layer:**
  - Introduces new API types for group requests and responses, including validation logic for creating and updating groups in `api/group.go`.

* **Service and Model Layer:**
  - Implements the `groupService` with methods for creating, retrieving, updating, and deleting groups, handling application membership, and error management in `pkg/services/group/service.go`.
  - Adds corresponding group model types in `pkg/model/group.go`.
  - Adds translation logic between storage and model layers for groups and their members in `pkg/services/group/translator.go`.

* **HTTP Routing and Handlers:**
  - Adds group-related HTTP handlers for all CRUD operations and integrates them into the authenticated route registration in `pkg/routes/group/group.go`, `pkg/routes/routes.go`, and related files.
  - Implements translation logic for API responses in `pkg/routes/group/translator.go`.

**Monitoring Integration:**

* Adds a new endpoint to retrieve monitoring interactions for all applications in a group, with handler and route registration in `pkg/routes/monitoring/monitoring.go`.